### PR TITLE
refactor: split VeilRoot render state composer

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1,10 +1,5 @@
 import { _decorator, Camera, Canvas, Color, Component, EventMouse, EventTouch, Graphics, input, Input, Label, Layers, Node, sys, UITransform, view } from "cc";
-import {
-  getBuildingUpgradeConfig,
-  getEquipmentDefinition,
-  getRuntimeConfigBundleForRoom,
-  type EquipmentType
-} from "./project-shared/index.ts";
+import { getBuildingUpgradeConfig, getEquipmentDefinition, type EquipmentType } from "./project-shared/index.ts";
 import {
   type BattleAction,
   type LeaderboardEntry,
@@ -18,13 +13,7 @@ import {
   type SessionUpdate,
   type Vec2
 } from "./VeilCocosSession.ts";
-import {
-  buildCocosAccountReviewPage,
-  createCocosAccountReviewState,
-  transitionCocosAccountReviewState,
-  type CocosAccountReviewSection,
-  type CocosAccountReviewState
-} from "./cocos-account-review.ts";
+import { createCocosAccountReviewState, transitionCocosAccountReviewState, type CocosAccountReviewSection, type CocosAccountReviewState } from "./cocos-account-review.ts";
 import {
   loadCocosCampaignSummary,
   claimCocosDailyQuest,
@@ -151,7 +140,7 @@ import {
   resolveCocosLaunchIdentity,
   type CocosAuthProvider
 } from "./cocos-session-launch.ts";
-import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts";
+import { type ShopProduct } from "./cocos-shop-panel.ts";
 import { resolveCocosClientVersion } from "./cocos-client-version.ts";
 import {
   type CocosDailyDungeonSummary,
@@ -164,7 +153,6 @@ import { VeilCampaignPanel } from "./VeilCampaignPanel.ts";
 import { VeilTutorialOverlay, type TutorialOverlayView } from "./VeilTutorialOverlay.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
-import { buildLobbySkillPanelView, toLobbySkillPanelHeroState } from "./cocos-lobby-skill-panel.ts";
 import {
   createCocosBattlePresentationController,
   type CocosBattlePresentationState
@@ -186,10 +174,7 @@ import {
   type CocosSettingsPanelUpdate,
   type CocosSettingsPanelView
 } from "./cocos-settings-panel.ts";
-import { buildCocosRuntimeTriageSummaryLines } from "./cocos-runtime-diagnostics.ts";
-import { buildCocosWorldFocusView } from "./cocos-world-focus.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
-import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import { type CocosCampaignDialogueState } from "./cocos-campaign-panel.ts";
 import {
@@ -228,6 +213,9 @@ import {
   collapseAdjacentEntries,
   connectSessionForRoot,
   createSessionOptionsForRoot,
+  buildBattleSettlementRecoveryStateForRoot,
+  buildHudPresentationStateForRoot,
+  buildHudSessionIndicatorsForRoot,
   claimGameplayDailyDungeonRunForRoot,
   claimGameplaySeasonTierForRoot,
   completeGameplayCampaignMissionForRoot,
@@ -255,6 +243,7 @@ import {
   refreshDailyDungeonPanelForRoot,
   refreshGameplayCampaignForRoot,
   refreshSeasonProgressForRoot,
+  renderViewForRoot,
   renderGameplayAccountReviewPanelForRoot,
   renderGameplayCampaignPanelForRoot,
   renderGameplayEquipmentPanelForRoot,
@@ -1309,239 +1298,7 @@ export class VeilRoot extends Component {
   }
 
   private renderView(): void {
-    if (this.levelUpNotice && this.levelUpNotice.expiresAt <= Date.now()) {
-      this.levelUpNotice = null;
-    }
-    if (this.achievementNotice && this.achievementNotice.expiresAt <= Date.now()) {
-      this.achievementNotice = null;
-    }
-    if (this.battleFeedback && this.battleFeedback.expiresAt <= Date.now()) {
-      this.battleFeedback = null;
-    }
-
-    this.ensurePixelSpriteGroup("boot");
-    if (this.lastUpdate?.battle) {
-      this.ensurePixelSpriteGroup("battle");
-    }
-
-    this.syncMusicScene();
-
-    this.updateLayout();
-    const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
-    const hudNode = this.node.getChildByName(HUD_NODE_NAME);
-    const mapNode = this.node.getChildByName(MAP_NODE_NAME);
-    const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
-    const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
-    const tutorialOverlayNode = this.node.getChildByName(TUTORIAL_OVERLAY_NODE_NAME);
-    const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
-    const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
-    const campaignPanelNode = this.node.getChildByName(CAMPAIGN_PANEL_NODE_NAME);
-    const settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
-    const settingsButtonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
-    const showingGame = !this.showLobby;
-
-    if (lobbyNode) {
-      lobbyNode.active = this.showLobby;
-    }
-    if (hudNode) {
-      hudNode.active = showingGame;
-    }
-    if (mapNode) {
-      mapNode.active = showingGame;
-    }
-    if (battleNode) {
-      battleNode.active = showingGame;
-    }
-    if (timelineNode) {
-      timelineNode.active = showingGame;
-    }
-    if (accountReviewPanelNode) {
-      accountReviewPanelNode.active =
-        showingGame && (this.gameplayAccountReviewPanelOpen || this.gameplayBattlePassPanelOpen || this.gameplayDailyDungeonPanelOpen || this.gameplaySeasonalEventPanelOpen);
-    }
-    if (equipmentPanelNode) {
-      equipmentPanelNode.active = showingGame && this.gameplayEquipmentPanelOpen;
-    }
-    if (campaignPanelNode) {
-      campaignPanelNode.active = this.gameplayCampaignPanelOpen;
-    }
-    if (settingsPanelNode) {
-      settingsPanelNode.active = this.settingsView.open;
-    }
-    if (settingsButtonNode) {
-      settingsButtonNode.active = true;
-    }
-    if (tutorialOverlayNode) {
-      tutorialOverlayNode.active = false;
-    }
-
-    if (this.showLobby) {
-      const activeHero = this.activeHero();
-      const runtimeBundle = this.lastUpdate
-        ? getRuntimeConfigBundleForRoom(this.lastUpdate.world.meta.roomId, this.lastUpdate.world.meta.seed)
-        : null;
-      this.lobbyPanel?.render({
-        playerId: this.playerId,
-        displayName: this.displayName || this.playerId,
-        roomId: this.roomId,
-        authMode: this.authMode,
-        loginId: this.loginId,
-        privacyConsentAccepted: this.privacyConsentAccepted,
-        loginHint: this.describeLobbyLoginHint(),
-        loginActionLabel: this.primaryLoginProvider().label,
-        shareHint: this.describeLobbyShareHint(),
-        vaultSummary: this.formatLobbyVaultSummary(),
-        account: this.lobbyAccountProfile,
-        campaign: this.gameplayCampaign,
-        campaignStatus: this.gameplayCampaignStatus,
-        dailyDungeon: this.dailyDungeonSummary,
-        dailyDungeonStatus: this.dailyDungeonStatus,
-        accountReview: buildCocosAccountReviewPage(this.lobbyAccountReviewState),
-        battleReplayItems: this.lobbyAccountReviewState.battleReplays.items,
-        battleReplaySectionStatus: this.lobbyAccountReviewState.battleReplays.status,
-        battleReplaySectionError: this.lobbyAccountReviewState.battleReplays.errorMessage,
-        selectedBattleReplayId: this.lobbyAccountReviewState.selectedBattleReplayId,
-        leaderboardEntries: this.lobbyLeaderboardEntries,
-        leaderboardStatus: this.lobbyLeaderboardStatus,
-        leaderboardError: this.lobbyLeaderboardError,
-        sessionSource: this.sessionSource,
-        loading: this.lobbyLoading,
-        entering: this.lobbyEntering,
-        status: this.lobbyStatus,
-        announcements: this.lobbyAnnouncements,
-        maintenanceMode: this.lobbyMaintenanceMode,
-        matchmaking: this.matchmakingView,
-        matchmakingSearching: this.isMatchmakingActive(),
-        matchmakingBusy: this.lobbyEntering || this.matchmakingJoinInFlight,
-        rooms: this.lobbyRooms,
-        accountFlow: this.buildActiveAccountFlowPanelView(),
-        presentationReadiness: cocosPresentationReadiness,
-        activeHero,
-        lobbySkillPanel: activeHero && runtimeBundle
-          ? buildLobbySkillPanelView(toLobbySkillPanelHeroState(activeHero), runtimeBundle)
-          : null,
-        battleActive: Boolean(this.lastUpdate?.battle),
-        skillPanelBusy: this.moveInFlight || this.battleActionInFlight,
-        shop: buildCocosShopPanelView({
-          products: this.lobbyShopProducts,
-          gemBalance: this.lobbyAccountProfile.gems ?? 0,
-          pendingProductId: this.pendingShopProductId,
-          experiments: this.lobbyAccountProfile.experiments ?? [],
-          ownedCosmeticIds: this.lobbyAccountProfile.cosmeticInventory?.ownedIds ?? [],
-          seasonPassPremiumOwned: this.lobbyAccountProfile.seasonPassPremium === true,
-          ...(this.lobbyAccountProfile.equippedCosmetics ? { equippedCosmetics: this.lobbyAccountProfile.equippedCosmetics } : {})
-        }),
-        shopStatus: this.lobbyShopStatus,
-        shopLoading: this.lobbyShopLoading,
-        seasonProgress: this.seasonProgress,
-        activeSeasonalEvent: this.activeSeasonalEvent,
-        dailyQuestClaimingId: this.dailyQuestClaimingId,
-        mailboxClaimingMessageId: this.mailboxClaimingMessageId,
-        mailboxClaimAllBusy: this.mailboxClaimAllInFlight
-      });
-      const tutorialOverlayView = this.buildTutorialOverlayView();
-      if (tutorialOverlayView) {
-        tutorialOverlayNode && (tutorialOverlayNode.active = true);
-        this.tutorialOverlay?.render(tutorialOverlayView);
-      } else {
-        this.tutorialOverlay?.render(null);
-      }
-      this.renderSettingsOverlay();
-      return;
-    }
-
-    this.hudPanel?.render({
-      roomId: this.roomId,
-      playerId: this.playerId,
-      displayName: this.displayName || this.playerId,
-      account: this.lobbyAccountProfile,
-      authMode: this.authMode,
-      loginId: this.loginId,
-      sessionSource: this.sessionSource,
-      remoteUrl: this.remoteUrl,
-      update: this.lastUpdate,
-      moveInFlight: this.moveInFlight,
-      predictionStatus: this.predictionStatus,
-      sessionIndicators: this.buildHudSessionIndicators(),
-      inputDebug: this.inputDebug,
-      runtimeHealth: this.describeRuntimeMemoryHealth(),
-      triageSummaryLines: buildCocosRuntimeTriageSummaryLines({
-        devOnly: true,
-        mode: this.lastUpdate?.battle ? "battle" : "world",
-        roomId: this.roomId,
-        playerId: this.playerId,
-        connectionStatus: this.diagnosticsConnectionStatus,
-        lastUpdateSource: this.lastRoomUpdateSource,
-        lastUpdateReason: this.lastRoomUpdateReason,
-        lastUpdateAt: this.lastRoomUpdateAtMs,
-        update: this.lastUpdate,
-        account: this.lobbyAccountProfile,
-        timelineEntries: this.timelineEntries,
-        logLines: this.logLines,
-        predictionStatus: this.predictionStatus,
-        recoverySummary: this.predictionStatus.includes("回放缓存状态") ? this.predictionStatus : null,
-        primaryClientTelemetry: this.primaryClientTelemetry
-      }),
-      levelUpNotice: this.levelUpNotice ? { title: this.levelUpNotice.title, detail: this.levelUpNotice.detail } : null,
-      achievementNotice: this.achievementNotice
-        ? { title: this.achievementNotice.title, detail: this.achievementNotice.detail }
-        : null,
-      reporting: {
-        open: this.reportDialogOpen,
-        available: Boolean(this.resolveReportTarget()),
-        targetLabel: this.resolveReportTarget()?.name ?? null,
-        status: this.reportStatusMessage,
-        submitting: this.reportSubmitting
-      },
-      surrendering: {
-        open: this.surrenderDialogOpen,
-        available: this.isSurrenderAvailable(),
-        targetLabel: this.resolveSurrenderTarget()?.name ?? null,
-        status: this.surrenderStatusMessage,
-        submitting: this.surrenderSubmitting
-      },
-      sharing: {
-        available: this.canShareLatestBattleResult()
-      },
-      battlePassEnabled: this.lastUpdate?.featureFlags?.battle_pass_enabled === true,
-      seasonalEventAvailable: this.activeSeasonalEvent != null,
-      interaction: this.buildHudInteractionState(),
-      presentation: this.buildHudPresentationState(),
-      worldFocus: buildCocosWorldFocusView({
-        update: this.lastUpdate,
-        interaction: this.buildHudInteractionState(),
-        predictionStatus: this.predictionStatus,
-        levelUpNotice: this.levelUpNotice ? { title: this.levelUpNotice.title, detail: this.levelUpNotice.detail } : null,
-        account: this.lobbyAccountProfile
-      })
-    });
-    const tutorialOverlayView = this.buildTutorialOverlayView();
-    if (tutorialOverlayView) {
-      tutorialOverlayNode && (tutorialOverlayNode.active = true);
-      this.tutorialOverlay?.render(tutorialOverlayView);
-    } else {
-      this.tutorialOverlay?.render(null);
-    }
-    this.renderSettingsOverlay();
-    this.mapBoard?.render(this.lastUpdate);
-    this.battlePanel?.render({
-      update: this.lastUpdate,
-      timelineEntries: this.timelineEntries,
-      controlledCamp: this.controlledBattleCamp(),
-      selectedTargetId: this.selectedBattleTargetId,
-      actionPending: this.battleActionInFlight,
-      feedback: this.battleFeedback,
-      presentationState: this.battlePresentation.getState(),
-      recovery: this.buildBattleSettlementRecoveryState(),
-      connectionStatus: this.diagnosticsConnectionStatus,
-      predictionStatus: this.predictionStatus
-    });
-    this.timelinePanel?.render({
-      entries: this.timelineEntries
-    });
-    this.renderGameplayEquipmentPanel();
-    this.renderGameplayCampaignPanel();
-    this.renderGameplayAccountReviewPanel();
+    renderViewForRoot(this as unknown as Record<string, any>);
   }
 
   private renderGameplayEquipmentPanel(): void {
@@ -5462,56 +5219,7 @@ export class VeilRoot extends Component {
     tone: CocosBattleFeedbackView["tone"];
     summaryLines: string[];
   } | null {
-    if (!this.lastBattleSettlementSnapshot || this.lastUpdate?.battle) {
-      return null;
-    }
-
-    const recoverySummaryLines = [
-      `最近结算：${this.lastBattleSettlementSnapshot.label}`,
-      ...this.lastBattleSettlementSnapshot.summaryLines
-    ];
-
-    if (this.diagnosticsConnectionStatus === "reconnecting") {
-      return {
-        title: "结算恢复中",
-        detail: "已保留最近一次结算摘要，正在等待权威房间确认奖励、战利品与英雄同步；不会重复发放奖励。",
-        badge: "RECOVER",
-        tone: "neutral",
-        summaryLines: recoverySummaryLines
-      };
-    }
-
-    if (this.lastRoomUpdateSource === "replay" && this.lastRoomUpdateReason === "cached_snapshot") {
-      return {
-        title: "结算快照回放中",
-        detail: "当前面板正在展示本地缓存的结算快照，等待服务端权威状态完成覆盖。",
-        badge: "REPLAY",
-        tone: "neutral",
-        summaryLines: recoverySummaryLines
-      };
-    }
-
-    if (this.diagnosticsConnectionStatus === "reconnect_failed") {
-      return {
-        title: "结算快照回补中",
-        detail: "重连失败后已转入快照回补；当前结算摘要仅作恢复提示，最终奖励与装备状态仍以服务端快照为准。",
-        badge: "FALLBACK",
-        tone: "neutral",
-        summaryLines: recoverySummaryLines
-      };
-    }
-
-    if (this.lastUpdate?.reason?.includes("reconnect.restore")) {
-      return {
-        title: "结算已恢复",
-        detail: "权威房间已恢复，以下结算摘要与战后状态已重新对齐到服务端快照。",
-        badge: "RESUMED",
-        tone: "victory",
-        summaryLines: recoverySummaryLines
-      };
-    }
-
-    return null;
+    return buildBattleSettlementRecoveryStateForRoot(this as unknown as Record<string, any>);
   }
 
   private captureBattleSettlementSnapshot(
@@ -5535,49 +5243,7 @@ export class VeilRoot extends Component {
   }
 
   private buildHudSessionIndicators(): VeilHudRenderState["sessionIndicators"] {
-    const indicators: VeilHudRenderState["sessionIndicators"] = [];
-    const replayingCachedSnapshot =
-      this.lastRoomUpdateSource === "replay" && this.lastRoomUpdateReason === "cached_snapshot";
-    const activePvpBattle = this.lastUpdate?.battle?.defenderHeroId
-      ? {
-          sessionId: `${this.lastUpdate.world.meta.roomId}/${this.lastUpdate.battle.id}`
-        }
-      : null;
-
-    if (this.diagnosticsConnectionStatus === "reconnecting") {
-      indicators.push({
-        kind: "reconnecting",
-        label: activePvpBattle ? "PVP 重连中" : "重连中",
-        detail: activePvpBattle
-          ? `正在恢复 ${activePvpBattle.sessionId} 的对手归属、当前回合与权威房间状态。`
-          : "正在尝试恢复与权威房间的连接。"
-      });
-    }
-
-    if (replayingCachedSnapshot) {
-      indicators.push({
-        kind: "replaying_cached_snapshot",
-        label: "缓存快照回放",
-        detail: "当前 HUD 正在展示本地缓存的上一份会话快照。"
-      });
-      indicators.push({
-        kind: "awaiting_authoritative_resync",
-        label: "等待权威重同步",
-        detail: "请等待服务端权威快照覆盖当前回放状态。"
-      });
-    }
-
-    if (this.diagnosticsConnectionStatus === "reconnect_failed") {
-      indicators.push({
-        kind: "degraded_offline_fallback",
-        label: activePvpBattle ? "PVP 快照回补" : "降级/离线回退",
-        detail: activePvpBattle
-          ? `最近一次 ${activePvpBattle.sessionId} 重连失败，客户端正依赖回退路径恢复当前对抗结果。`
-          : "最近一次重连失败，客户端正依赖回退路径维持会话。"
-      });
-    }
-
-    return indicators;
+    return buildHudSessionIndicatorsForRoot(this as unknown as Record<string, any>);
   }
 
   private applyPrediction(action: CocosWorldAction, status: string): void {
@@ -5633,11 +5299,7 @@ export class VeilRoot extends Component {
   }
 
   private buildHudPresentationState(): VeilHudRenderState["presentation"] {
-    return {
-      audio: this.audioRuntime.getState(),
-      pixelAssets: getPixelSpriteLoadStatus(),
-      readiness: cocosPresentationReadiness
-    };
+    return buildHudPresentationStateForRoot(this as unknown as Record<string, any>);
   }
 
 }

--- a/apps/cocos-client/assets/scripts/root/index.ts
+++ b/apps/cocos-client/assets/scripts/root/index.ts
@@ -5,5 +5,6 @@ export * from "./formatters";
 export * from "./session-helpers";
 export * from "./session-lifecycle";
 export * from "./panel-orchestration";
+export * from "./render-state-composer";
 export * from "./telemetry-hooks";
 export * from "./tutorial-orchestrator";

--- a/apps/cocos-client/assets/scripts/root/render-state-composer.ts
+++ b/apps/cocos-client/assets/scripts/root/render-state-composer.ts
@@ -1,0 +1,393 @@
+import { getRuntimeConfigBundleForRoom } from "../project-shared/index.ts";
+import { buildCocosAccountReviewPage } from "../cocos-account-review.ts";
+import type { CocosBattleFeedbackView } from "../cocos-battle-feedback.ts";
+import { buildLobbySkillPanelView, toLobbySkillPanelHeroState } from "../cocos-lobby-skill-panel.ts";
+import { buildCocosRuntimeTriageSummaryLines } from "../cocos-runtime-diagnostics.ts";
+import { buildCocosShopPanelView } from "../cocos-shop-panel.ts";
+import { buildCocosWorldFocusView } from "../cocos-world-focus.ts";
+import { cocosPresentationReadiness } from "../cocos-presentation-readiness.ts";
+import { getPixelSpriteLoadStatus } from "../cocos-pixel-sprites.ts";
+import type { VeilHudRenderState } from "../VeilHudPanel.ts";
+import {
+  ACCOUNT_REVIEW_PANEL_NODE_NAME,
+  BATTLE_NODE_NAME,
+  CAMPAIGN_PANEL_NODE_NAME,
+  EQUIPMENT_PANEL_NODE_NAME,
+  HUD_NODE_NAME,
+  LOBBY_NODE_NAME,
+  MAP_NODE_NAME,
+  SETTINGS_BUTTON_NODE_NAME,
+  SETTINGS_PANEL_NODE_NAME,
+  TIMELINE_NODE_NAME,
+  TUTORIAL_OVERLAY_NODE_NAME
+} from "./constants";
+
+type VeilRootRenderState = any;
+
+function expireTransientNoticesForRoot(state: VeilRootRenderState): void {
+  if (state.levelUpNotice && state.levelUpNotice.expiresAt <= Date.now()) {
+    state.levelUpNotice = null;
+  }
+  if (state.achievementNotice && state.achievementNotice.expiresAt <= Date.now()) {
+    state.achievementNotice = null;
+  }
+  if (state.battleFeedback && state.battleFeedback.expiresAt <= Date.now()) {
+    state.battleFeedback = null;
+  }
+}
+
+export function buildBattleSettlementRecoveryStateForRoot(
+  state: VeilRootRenderState
+): {
+  title: string;
+  detail: string;
+  badge: string;
+  tone: CocosBattleFeedbackView["tone"];
+  summaryLines: string[];
+} | null {
+  if (!state.lastBattleSettlementSnapshot || state.lastUpdate?.battle) {
+    return null;
+  }
+
+  const recoverySummaryLines = [
+    `最近结算：${state.lastBattleSettlementSnapshot.label}`,
+    ...state.lastBattleSettlementSnapshot.summaryLines
+  ];
+
+  if (state.diagnosticsConnectionStatus === "reconnecting") {
+    return {
+      title: "结算恢复中",
+      detail: "已保留最近一次结算摘要，正在等待权威房间确认奖励、战利品与英雄同步；不会重复发放奖励。",
+      badge: "RECOVER",
+      tone: "neutral",
+      summaryLines: recoverySummaryLines
+    };
+  }
+
+  if (state.lastRoomUpdateSource === "replay" && state.lastRoomUpdateReason === "cached_snapshot") {
+    return {
+      title: "结算快照回放中",
+      detail: "当前面板正在展示本地缓存的结算快照，等待服务端权威状态完成覆盖。",
+      badge: "REPLAY",
+      tone: "neutral",
+      summaryLines: recoverySummaryLines
+    };
+  }
+
+  if (state.diagnosticsConnectionStatus === "reconnect_failed") {
+    return {
+      title: "结算快照回补中",
+      detail: "重连失败后已转入快照回补；当前结算摘要仅作恢复提示，最终奖励与装备状态仍以服务端快照为准。",
+      badge: "FALLBACK",
+      tone: "neutral",
+      summaryLines: recoverySummaryLines
+    };
+  }
+
+  if (state.lastUpdate?.reason?.includes("reconnect.restore")) {
+    return {
+      title: "结算已恢复",
+      detail: "权威房间已恢复，以下结算摘要与战后状态已重新对齐到服务端快照。",
+      badge: "RESUMED",
+      tone: "victory",
+      summaryLines: recoverySummaryLines
+    };
+  }
+
+  return null;
+}
+
+export function buildHudSessionIndicatorsForRoot(
+  state: VeilRootRenderState
+): VeilHudRenderState["sessionIndicators"] {
+  const indicators: VeilHudRenderState["sessionIndicators"] = [];
+  const replayingCachedSnapshot =
+    state.lastRoomUpdateSource === "replay" && state.lastRoomUpdateReason === "cached_snapshot";
+  const activePvpBattle = state.lastUpdate?.battle?.defenderHeroId
+    ? {
+        sessionId: `${state.lastUpdate.world.meta.roomId}/${state.lastUpdate.battle.id}`
+      }
+    : null;
+
+  if (state.diagnosticsConnectionStatus === "reconnecting") {
+    indicators.push({
+      kind: "reconnecting",
+      label: activePvpBattle ? "PVP 重连中" : "重连中",
+      detail: activePvpBattle
+        ? `正在恢复 ${activePvpBattle.sessionId} 的对手归属、当前回合与权威房间状态。`
+        : "正在尝试恢复与权威房间的连接。"
+    });
+  }
+
+  if (replayingCachedSnapshot) {
+    indicators.push({
+      kind: "replaying_cached_snapshot",
+      label: "缓存快照回放",
+      detail: "当前 HUD 正在展示本地缓存的上一份会话快照。"
+    });
+    indicators.push({
+      kind: "awaiting_authoritative_resync",
+      label: "等待权威重同步",
+      detail: "请等待服务端权威快照覆盖当前回放状态。"
+    });
+  }
+
+  if (state.diagnosticsConnectionStatus === "reconnect_failed") {
+    indicators.push({
+      kind: "degraded_offline_fallback",
+      label: activePvpBattle ? "PVP 快照回补" : "降级/离线回退",
+      detail: activePvpBattle
+        ? `最近一次 ${activePvpBattle.sessionId} 重连失败，客户端正依赖回退路径恢复当前对抗结果。`
+        : "最近一次重连失败，客户端正依赖回退路径维持会话。"
+    });
+  }
+
+  return indicators;
+}
+
+export function buildHudPresentationStateForRoot(
+  state: VeilRootRenderState
+): VeilHudRenderState["presentation"] {
+  return {
+    audio: state.audioRuntime.getState(),
+    pixelAssets: getPixelSpriteLoadStatus(),
+    readiness: cocosPresentationReadiness
+  };
+}
+
+export function renderViewForRoot(state: VeilRootRenderState): void {
+  expireTransientNoticesForRoot(state);
+
+  state.ensurePixelSpriteGroup("boot");
+  if (state.lastUpdate?.battle) {
+    state.ensurePixelSpriteGroup("battle");
+  }
+
+  state.syncMusicScene();
+  state.updateLayout();
+
+  const lobbyNode = state.node.getChildByName(LOBBY_NODE_NAME);
+  const hudNode = state.node.getChildByName(HUD_NODE_NAME);
+  const mapNode = state.node.getChildByName(MAP_NODE_NAME);
+  const battleNode = state.node.getChildByName(BATTLE_NODE_NAME);
+  const timelineNode = state.node.getChildByName(TIMELINE_NODE_NAME);
+  const tutorialOverlayNode = state.node.getChildByName(TUTORIAL_OVERLAY_NODE_NAME);
+  const accountReviewPanelNode = state.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+  const equipmentPanelNode = state.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+  const campaignPanelNode = state.node.getChildByName(CAMPAIGN_PANEL_NODE_NAME);
+  const settingsPanelNode = state.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
+  const settingsButtonNode = state.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
+  const showingGame = !state.showLobby;
+
+  if (lobbyNode) {
+    lobbyNode.active = state.showLobby;
+  }
+  if (hudNode) {
+    hudNode.active = showingGame;
+  }
+  if (mapNode) {
+    mapNode.active = showingGame;
+  }
+  if (battleNode) {
+    battleNode.active = showingGame;
+  }
+  if (timelineNode) {
+    timelineNode.active = showingGame;
+  }
+  if (accountReviewPanelNode) {
+    accountReviewPanelNode.active = showingGame && (
+      state.gameplayAccountReviewPanelOpen
+      || state.gameplayBattlePassPanelOpen
+      || state.gameplayDailyDungeonPanelOpen
+      || state.gameplaySeasonalEventPanelOpen
+    );
+  }
+  if (equipmentPanelNode) {
+    equipmentPanelNode.active = showingGame && state.gameplayEquipmentPanelOpen;
+  }
+  if (campaignPanelNode) {
+    campaignPanelNode.active = state.gameplayCampaignPanelOpen;
+  }
+  if (settingsPanelNode) {
+    settingsPanelNode.active = state.settingsView.open;
+  }
+  if (settingsButtonNode) {
+    settingsButtonNode.active = true;
+  }
+  if (tutorialOverlayNode) {
+    tutorialOverlayNode.active = false;
+  }
+
+  if (state.showLobby) {
+    const activeHero = state.activeHero();
+    const runtimeBundle = state.lastUpdate
+      ? getRuntimeConfigBundleForRoom(state.lastUpdate.world.meta.roomId, state.lastUpdate.world.meta.seed)
+      : null;
+    state.lobbyPanel?.render({
+      playerId: state.playerId,
+      displayName: state.displayName || state.playerId,
+      roomId: state.roomId,
+      authMode: state.authMode,
+      loginId: state.loginId,
+      privacyConsentAccepted: state.privacyConsentAccepted,
+      loginHint: state.describeLobbyLoginHint(),
+      loginActionLabel: state.primaryLoginProvider().label,
+      shareHint: state.describeLobbyShareHint(),
+      vaultSummary: state.formatLobbyVaultSummary(),
+      account: state.lobbyAccountProfile,
+      campaign: state.gameplayCampaign,
+      campaignStatus: state.gameplayCampaignStatus,
+      dailyDungeon: state.dailyDungeonSummary,
+      dailyDungeonStatus: state.dailyDungeonStatus,
+      accountReview: buildCocosAccountReviewPage(state.lobbyAccountReviewState),
+      battleReplayItems: state.lobbyAccountReviewState.battleReplays.items,
+      battleReplaySectionStatus: state.lobbyAccountReviewState.battleReplays.status,
+      battleReplaySectionError: state.lobbyAccountReviewState.battleReplays.errorMessage,
+      selectedBattleReplayId: state.lobbyAccountReviewState.selectedBattleReplayId,
+      leaderboardEntries: state.lobbyLeaderboardEntries,
+      leaderboardStatus: state.lobbyLeaderboardStatus,
+      leaderboardError: state.lobbyLeaderboardError,
+      sessionSource: state.sessionSource,
+      loading: state.lobbyLoading,
+      entering: state.lobbyEntering,
+      status: state.lobbyStatus,
+      announcements: state.lobbyAnnouncements,
+      maintenanceMode: state.lobbyMaintenanceMode,
+      matchmaking: state.matchmakingView,
+      matchmakingSearching: state.isMatchmakingActive(),
+      matchmakingBusy: state.lobbyEntering || state.matchmakingJoinInFlight,
+      rooms: state.lobbyRooms,
+      accountFlow: state.buildActiveAccountFlowPanelView(),
+      presentationReadiness: cocosPresentationReadiness,
+      activeHero,
+      lobbySkillPanel: activeHero && runtimeBundle
+        ? buildLobbySkillPanelView(toLobbySkillPanelHeroState(activeHero), runtimeBundle)
+        : null,
+      battleActive: Boolean(state.lastUpdate?.battle),
+      skillPanelBusy: state.moveInFlight || state.battleActionInFlight,
+      shop: buildCocosShopPanelView({
+        products: state.lobbyShopProducts,
+        gemBalance: state.lobbyAccountProfile.gems ?? 0,
+        pendingProductId: state.pendingShopProductId,
+        experiments: state.lobbyAccountProfile.experiments ?? [],
+        ownedCosmeticIds: state.lobbyAccountProfile.cosmeticInventory?.ownedIds ?? [],
+        seasonPassPremiumOwned: state.lobbyAccountProfile.seasonPassPremium === true,
+        ...(state.lobbyAccountProfile.equippedCosmetics
+          ? { equippedCosmetics: state.lobbyAccountProfile.equippedCosmetics }
+          : {})
+      }),
+      shopStatus: state.lobbyShopStatus,
+      shopLoading: state.lobbyShopLoading,
+      seasonProgress: state.seasonProgress,
+      activeSeasonalEvent: state.activeSeasonalEvent,
+      dailyQuestClaimingId: state.dailyQuestClaimingId,
+      mailboxClaimingMessageId: state.mailboxClaimingMessageId,
+      mailboxClaimAllBusy: state.mailboxClaimAllInFlight
+    });
+    const tutorialOverlayView = state.buildTutorialOverlayView();
+    if (tutorialOverlayView) {
+      tutorialOverlayNode && (tutorialOverlayNode.active = true);
+      state.tutorialOverlay?.render(tutorialOverlayView);
+    } else {
+      state.tutorialOverlay?.render(null);
+    }
+    state.renderSettingsOverlay();
+    return;
+  }
+
+  const hudInteraction = state.buildHudInteractionState();
+  state.hudPanel?.render({
+    roomId: state.roomId,
+    playerId: state.playerId,
+    displayName: state.displayName || state.playerId,
+    account: state.lobbyAccountProfile,
+    authMode: state.authMode,
+    loginId: state.loginId,
+    sessionSource: state.sessionSource,
+    remoteUrl: state.remoteUrl,
+    update: state.lastUpdate,
+    moveInFlight: state.moveInFlight,
+    predictionStatus: state.predictionStatus,
+    sessionIndicators: buildHudSessionIndicatorsForRoot(state),
+    inputDebug: state.inputDebug,
+    runtimeHealth: state.describeRuntimeMemoryHealth(),
+    triageSummaryLines: buildCocosRuntimeTriageSummaryLines({
+      devOnly: true,
+      mode: state.lastUpdate?.battle ? "battle" : "world",
+      roomId: state.roomId,
+      playerId: state.playerId,
+      connectionStatus: state.diagnosticsConnectionStatus,
+      lastUpdateSource: state.lastRoomUpdateSource,
+      lastUpdateReason: state.lastRoomUpdateReason,
+      lastUpdateAt: state.lastRoomUpdateAtMs,
+      update: state.lastUpdate,
+      account: state.lobbyAccountProfile,
+      timelineEntries: state.timelineEntries,
+      logLines: state.logLines,
+      predictionStatus: state.predictionStatus,
+      recoverySummary: state.predictionStatus.includes("回放缓存状态") ? state.predictionStatus : null,
+      primaryClientTelemetry: state.primaryClientTelemetry
+    }),
+    levelUpNotice: state.levelUpNotice
+      ? { title: state.levelUpNotice.title, detail: state.levelUpNotice.detail }
+      : null,
+    achievementNotice: state.achievementNotice
+      ? { title: state.achievementNotice.title, detail: state.achievementNotice.detail }
+      : null,
+    reporting: {
+      open: state.reportDialogOpen,
+      available: Boolean(state.resolveReportTarget()),
+      targetLabel: state.resolveReportTarget()?.name ?? null,
+      status: state.reportStatusMessage,
+      submitting: state.reportSubmitting
+    },
+    surrendering: {
+      open: state.surrenderDialogOpen,
+      available: state.isSurrenderAvailable(),
+      targetLabel: state.resolveSurrenderTarget()?.name ?? null,
+      status: state.surrenderStatusMessage,
+      submitting: state.surrenderSubmitting
+    },
+    sharing: {
+      available: state.canShareLatestBattleResult()
+    },
+    battlePassEnabled: state.lastUpdate?.featureFlags?.battle_pass_enabled === true,
+    seasonalEventAvailable: state.activeSeasonalEvent != null,
+    interaction: hudInteraction,
+    presentation: buildHudPresentationStateForRoot(state),
+    worldFocus: buildCocosWorldFocusView({
+      update: state.lastUpdate,
+      interaction: hudInteraction,
+      predictionStatus: state.predictionStatus,
+      levelUpNotice: state.levelUpNotice ? { title: state.levelUpNotice.title, detail: state.levelUpNotice.detail } : null,
+      account: state.lobbyAccountProfile
+    })
+  });
+  const tutorialOverlayView = state.buildTutorialOverlayView();
+  if (tutorialOverlayView) {
+    tutorialOverlayNode && (tutorialOverlayNode.active = true);
+    state.tutorialOverlay?.render(tutorialOverlayView);
+  } else {
+    state.tutorialOverlay?.render(null);
+  }
+  state.renderSettingsOverlay();
+  state.mapBoard?.render(state.lastUpdate);
+  state.battlePanel?.render({
+    update: state.lastUpdate,
+    timelineEntries: state.timelineEntries,
+    controlledCamp: state.controlledBattleCamp(),
+    selectedTargetId: state.selectedBattleTargetId,
+    actionPending: state.battleActionInFlight,
+    feedback: state.battleFeedback,
+    presentationState: state.battlePresentation.getState(),
+    recovery: buildBattleSettlementRecoveryStateForRoot(state),
+    connectionStatus: state.diagnosticsConnectionStatus,
+    predictionStatus: state.predictionStatus
+  });
+  state.timelinePanel?.render({
+    entries: state.timelineEntries
+  });
+  state.renderGameplayEquipmentPanel();
+  state.renderGameplayCampaignPanel();
+  state.renderGameplayAccountReviewPanel();
+}

--- a/apps/cocos-client/test/root-render-state-composer.test.ts
+++ b/apps/cocos-client/test/root-render-state-composer.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCocosAccountReviewState } from "../assets/scripts/cocos-account-review.ts";
+import { createFallbackCocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
+import {
+  buildBattleSettlementRecoveryStateForRoot,
+  buildHudPresentationStateForRoot,
+  buildHudSessionIndicatorsForRoot,
+  renderViewForRoot
+} from "../assets/scripts/root/render-state-composer.ts";
+import {
+  BATTLE_NODE_NAME,
+  HUD_NODE_NAME,
+  LOBBY_NODE_NAME,
+  MAP_NODE_NAME,
+  TIMELINE_NODE_NAME
+} from "../assets/scripts/root/constants.ts";
+
+test("buildBattleSettlementRecoveryStateForRoot describes reconnect and replay recovery states", () => {
+  const baseSnapshot = {
+    label: "首战告捷",
+    summaryLines: ["获得金币 20"],
+    detail: "detail",
+    badge: "WIN",
+    tone: "victory"
+  };
+
+  const reconnecting = buildBattleSettlementRecoveryStateForRoot({
+    lastBattleSettlementSnapshot: baseSnapshot,
+    lastUpdate: null,
+    diagnosticsConnectionStatus: "reconnecting",
+    lastRoomUpdateSource: "live",
+    lastRoomUpdateReason: null
+  });
+  assert.equal(reconnecting?.badge, "RECOVER");
+  assert.match(String(reconnecting?.detail), /等待权威房间/);
+
+  const replaying = buildBattleSettlementRecoveryStateForRoot({
+    lastBattleSettlementSnapshot: baseSnapshot,
+    lastUpdate: null,
+    diagnosticsConnectionStatus: "connected",
+    lastRoomUpdateSource: "replay",
+    lastRoomUpdateReason: "cached_snapshot"
+  });
+  assert.equal(replaying?.badge, "REPLAY");
+  assert.match(String(replaying?.detail), /缓存的结算快照/);
+});
+
+test("buildHudSessionIndicatorsForRoot surfaces reconnect, replay, and fallback indicators", () => {
+  const indicators = buildHudSessionIndicatorsForRoot({
+    diagnosticsConnectionStatus: "reconnect_failed",
+    lastRoomUpdateSource: "replay",
+    lastRoomUpdateReason: "cached_snapshot",
+    lastUpdate: {
+      world: {
+        meta: {
+          roomId: "room-1"
+        }
+      },
+      battle: {
+        id: "battle-1",
+        defenderHeroId: "enemy-1"
+      }
+    }
+  });
+
+  assert.deepEqual(
+    indicators.map((entry) => entry.kind),
+    ["replaying_cached_snapshot", "awaiting_authoritative_resync", "degraded_offline_fallback"]
+  );
+});
+
+test("buildHudPresentationStateForRoot returns audio, pixel assets, and readiness snapshot", () => {
+  const presentation = buildHudPresentationStateForRoot({
+    audioRuntime: {
+      getState() {
+        return { unlocked: true, scene: "explore" };
+      }
+    }
+  });
+
+  assert.equal(presentation.audio.unlocked, true);
+  assert.equal(typeof presentation.pixelAssets.loadedResourceCount, "number");
+  assert.equal(typeof presentation.readiness.summary, "string");
+});
+
+test("renderViewForRoot activates lobby chrome and forwards lobby render input in lobby mode", () => {
+  const nodeMap = new Map<string, { active: boolean }>([
+    [LOBBY_NODE_NAME, { active: false }],
+    [HUD_NODE_NAME, { active: true }],
+    [MAP_NODE_NAME, { active: true }],
+    [BATTLE_NODE_NAME, { active: true }],
+    [TIMELINE_NODE_NAME, { active: true }]
+  ]);
+  let renderedLobbyStatus = "";
+  let ensuredBoot = 0;
+  let layoutUpdated = 0;
+  let musicSyncs = 0;
+
+  const account = createFallbackCocosPlayerAccountProfile("player-1", "room-1", "旅人");
+  const state = {
+    levelUpNotice: null,
+    achievementNotice: null,
+    battleFeedback: null,
+    lastUpdate: null,
+    showLobby: true,
+    playerId: "player-1",
+    displayName: "",
+    roomId: "room-1",
+    authMode: "guest",
+    loginId: "",
+    privacyConsentAccepted: false,
+    lobbyAccountProfile: account,
+    gameplayCampaign: null,
+    gameplayCampaignStatus: "战役待同步",
+    dailyDungeonSummary: null,
+    dailyDungeonStatus: "地城待同步",
+    lobbyAccountReviewState: createCocosAccountReviewState(account),
+    lobbyLeaderboardEntries: [],
+    lobbyLeaderboardStatus: "idle",
+    lobbyLeaderboardError: null,
+    sessionSource: "none",
+    lobbyLoading: false,
+    lobbyEntering: false,
+    lobbyStatus: "请选择房间",
+    lobbyAnnouncements: [],
+    lobbyMaintenanceMode: null,
+    matchmakingView: { status: "idle" },
+    dailyQuestClaimingId: null,
+    mailboxClaimingMessageId: null,
+    mailboxClaimAllInFlight: false,
+    activeSeasonalEvent: null,
+    seasonProgress: null,
+    lobbyShopProducts: [],
+    lobbyShopStatus: "shop",
+    lobbyShopLoading: false,
+    pendingShopProductId: null,
+    moveInFlight: false,
+    battleActionInFlight: false,
+    settingsView: { open: false },
+    node: {
+      getChildByName(name: string) {
+        return nodeMap.get(name) ?? null;
+      }
+    },
+    ensurePixelSpriteGroup(group: string) {
+      if (group === "boot") {
+        ensuredBoot += 1;
+      }
+    },
+    syncMusicScene() {
+      musicSyncs += 1;
+    },
+    updateLayout() {
+      layoutUpdated += 1;
+    },
+    activeHero() {
+      return null;
+    },
+    describeLobbyLoginHint() {
+      return "hint";
+    },
+    primaryLoginProvider() {
+      return { label: "登录" };
+    },
+    describeLobbyShareHint() {
+      return "share";
+    },
+    formatLobbyVaultSummary() {
+      return "vault";
+    },
+    isMatchmakingActive() {
+      return false;
+    },
+    buildActiveAccountFlowPanelView() {
+      return null;
+    },
+    lobbyPanel: {
+      render(input: { status: string }) {
+        renderedLobbyStatus = input.status;
+      }
+    },
+    buildTutorialOverlayView() {
+      return null;
+    },
+    tutorialOverlay: {
+      render() {}
+    },
+    renderSettingsOverlay() {}
+  };
+
+  renderViewForRoot(state);
+
+  assert.equal(nodeMap.get(LOBBY_NODE_NAME)?.active, true);
+  assert.equal(nodeMap.get(HUD_NODE_NAME)?.active, false);
+  assert.equal(renderedLobbyStatus, "请选择房间");
+  assert.equal(ensuredBoot, 1);
+  assert.equal(layoutUpdated, 1);
+  assert.equal(musicSyncs, 1);
+});

--- a/progress.md
+++ b/progress.md
@@ -2246,3 +2246,15 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮补充验证已通过：
   - `npm run typecheck:cocos`
   - `node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-panel-orchestration.test.ts ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
+
+- 同一轮继续把 `render state composer` 抽进了 `root/`：
+  - `apps/cocos-client/assets/scripts/root/render-state-composer.ts`
+    - 收拢 `renderView` 本体，以及 `HUD session indicators / battle settlement recovery / HUD presentation` 这组渲染输入拼装逻辑
+- `apps/cocos-client/assets/scripts/VeilRoot.ts`
+  - 对应渲染与恢复状态方法已经改成轻量委托层，主文件从 `5645` 行继续降到 `5307` 行
+- 新增模块级测试：
+  - `apps/cocos-client/test/root-render-state-composer.test.ts`
+- 本轮补充验证已通过：
+  - `npm run typecheck:cocos`
+  - `node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-render-state-composer.test.ts ./apps/cocos-client/test/root-panel-orchestration.test.ts ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
+  - `npm run smoke:cocos:canonical-journey`


### PR DESCRIPTION
## Summary\n- extract VeilRoot render-state composition into root/render-state-composer\n- add focused render-state composer coverage alongside the existing root split tests\n- continue shrinking VeilRoot while keeping issue #1561 open for the remaining prefetch/layout slices\n\n## Testing\n- npm run typecheck:cocos\n- node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-render-state-composer.test.ts ./apps/cocos-client/test/root-panel-orchestration.test.ts ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts\n- npm run smoke:cocos:canonical-journey