### PR TITLE
[codex] fix campaign smoke runtime targeting

### DIFF
--- a/tests/e2e/admin-sync.spec.ts
+++ b/tests/e2e/admin-sync.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from './fixtures';
+import { ADMIN_BASE_URL, CLIENT_BASE_URL } from "./runtime-targets";
 
 test('Admin Console 联动测试: 修改资源并验证实时同步', async ({ browser }) => {
   // 1. 创建玩家页面 (H5 Client)
   const playerContext = await browser.newContext();
   const playerPage = await playerContext.newPage();
-  await playerPage.goto('http://127.0.0.1:4173');
+  await playerPage.goto(CLIENT_BASE_URL);
   
   // 模拟登录 player-1
   const nameInput = playerPage.locator('input[placeholder*="ID"], input[type="text"]').first();
@@ -17,7 +18,7 @@ test('Admin Console 联动测试: 修改资源并验证实时同步', async ({ b
   // 2. 创建管理员页面 (Admin Console)
   const adminContext = await browser.newContext();
   const adminPage = await adminContext.newPage();
-  await adminPage.goto('http://127.0.0.1:2567/admin');
+  await adminPage.goto(ADMIN_BASE_URL);
   
   // 输入 Player ID 并修改资源
   await adminPage.fill('#targetPlayerId', 'player-1');

--- a/tests/e2e/analytics-helpers.ts
+++ b/tests/e2e/analytics-helpers.ts
@@ -1,8 +1,6 @@
 import { expect, type APIRequestContext } from "@playwright/test";
 import { ANALYTICS_EVENT_CATALOG, type AnalyticsEvent, type AnalyticsEventName } from "../../packages/shared/src/analytics-events";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
-const ANALYTICS_CAPTURE_ENDPOINT = `${SERVER_BASE_URL}/api/test/analytics/events`;
+import { ANALYTICS_CAPTURE_ENDPOINT } from "./runtime-targets";
 
 interface AnalyticsCapturePayload {
   events?: AnalyticsEvent[];

--- a/tests/e2e/battle-pass-progression.spec.ts
+++ b/tests/e2e/battle-pass-progression.spec.ts
@@ -6,9 +6,7 @@ import {
   type PlayerWorldView,
   type SessionStatePayload
 } from "../../packages/shared/src/index";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
-const SERVER_WS_URL = "ws://127.0.0.1:2567";
+import { SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
 const BATTLE_PASS_TIER = 2;
 const BATTLE_PASS_TIER_XP_REQUIRED = 500;
 const BATTLE_PASS_TIER_REWARD = {

--- a/tests/e2e/battle-replay-smoke.spec.ts
+++ b/tests/e2e/battle-replay-smoke.spec.ts
@@ -8,8 +8,7 @@ import {
   resolveBattleToSettlement,
   withSmokeDiagnostics
 } from "./smoke-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 
 interface PlayerBattleReplaySummary {
   id: string;

--- a/tests/e2e/campaign-mission-flow.spec.ts
+++ b/tests/e2e/campaign-mission-flow.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
 import { pollForAnalyticsEvent } from "./analytics-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 const FIRST_MISSION_ID = "chapter1-ember-watch";
 const FIRST_MISSION_MAP_ID = "amber-fields";
 const FIRST_CHAPTER_ID = "chapter1";

--- a/tests/e2e/daily-dungeon.spec.ts
+++ b/tests/e2e/daily-dungeon.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 const ACTIVE_WINDOW_NOW = "2026-04-10T12:00:00.000Z";
 const INACTIVE_WINDOW_NOW = "2026-05-12T12:00:00.000Z";
 const ACTIVE_DUNGEON_ID = "shadow-archives";

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,8 +1,5 @@
 import { test as base } from "@playwright/test";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
-const CLIENT_BASE_URL = "http://127.0.0.1:4173";
-const RESET_ENDPOINT = `${SERVER_BASE_URL}/api/test/reset-store`;
+import { CLIENT_BASE_URL, RESET_ENDPOINT } from "./runtime-targets";
 
 /**
  * Custom test fixture that automatically resets the server's in-memory store

--- a/tests/e2e/guild-lifecycle.spec.ts
+++ b/tests/e2e/guild-lifecycle.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {

--- a/tests/e2e/leaderboard-ranked-season.spec.ts
+++ b/tests/e2e/leaderboard-ranked-season.spec.ts
@@ -12,8 +12,7 @@ import {
   resolveBattleToSettlement,
   startDeterministicPvpBattle
 } from "./smoke-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {

--- a/tests/e2e/lobby-smoke.spec.ts
+++ b/tests/e2e/lobby-smoke.spec.ts
@@ -7,6 +7,7 @@ import {
   waitForLobbyReady,
   withSmokeDiagnostics
 } from "./smoke-helpers";
+import { SERVER_BASE_URL } from "./runtime-targets";
 
 async function expectEnteredRoom(page: Page, roomId: string, playerId?: string): Promise<void> {
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
@@ -125,7 +126,7 @@ test("lobby supports password recovery and rotates the account password before e
   await withSmokeDiagnostics(testInfo, [page], async () => {
     await waitForLobbyReady(page);
 
-    const requestRegistrationResponse = await request.post("http://127.0.0.1:2567/api/auth/account-registration/request", {
+    const requestRegistrationResponse = await request.post(`${SERVER_BASE_URL}/api/auth/account-registration/request`, {
       data: {
         loginId,
         displayName
@@ -135,7 +136,7 @@ test("lobby supports password recovery and rotates the account password before e
     const requestRegistrationPayload = (await requestRegistrationResponse.json()) as { registrationToken?: string };
     expect(requestRegistrationPayload.registrationToken).toBeTruthy();
 
-    const confirmRegistrationResponse = await request.post("http://127.0.0.1:2567/api/auth/account-registration/confirm", {
+    const confirmRegistrationResponse = await request.post(`${SERVER_BASE_URL}/api/auth/account-registration/confirm`, {
       data: {
         loginId,
         registrationToken: requestRegistrationPayload.registrationToken,
@@ -160,7 +161,7 @@ test("lobby supports password recovery and rotates the account password before e
     await expect(page.getByTestId("account-card")).toContainText(displayName);
     await expect(page.getByTestId("account-card")).toContainText(`已绑定登录 ID：${loginId}`);
 
-    const oldPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
+    const oldPasswordLoginResponse = await request.post(`${SERVER_BASE_URL}/api/auth/account-login`, {
       data: {
         loginId,
         password: originalPassword
@@ -168,7 +169,7 @@ test("lobby supports password recovery and rotates the account password before e
     });
     expect(oldPasswordLoginResponse.status()).toBe(401);
 
-    const newPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
+    const newPasswordLoginResponse = await request.post(`${SERVER_BASE_URL}/api/auth/account-login`, {
       data: {
         loginId,
         password: nextPassword

--- a/tests/e2e/multiplayer-stress.spec.ts
+++ b/tests/e2e/multiplayer-stress.spec.ts
@@ -10,9 +10,7 @@ import {
   reloadAndExpectAuthoritativeConvergence,
   withSmokeDiagnostics
 } from "./smoke-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
-const SERVER_WS_URL = "ws://127.0.0.1:2567";
+import { SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
 
 interface AutomationState {
   hero?: {

--- a/tests/e2e/player-mailbox.spec.ts
+++ b/tests/e2e/player-mailbox.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token";
 const ACTIVE_MESSAGE_ID = "mailbox-e2e-active";
 const EXPIRED_MESSAGE_ID = "mailbox-e2e-expired";

--- a/tests/e2e/pvp-hero-encounter.spec.ts
+++ b/tests/e2e/pvp-hero-encounter.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import { expectHeroMoveSpent, followTilePath, resolveBattleToSettlement } from "./smoke-helpers";
+import { CLIENT_BASE_URL } from "./runtime-targets";
 
 async function pressTile(page: Page, x: number, y: number): Promise<void> {
   await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
@@ -15,8 +16,8 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   const playerTwoPage = await playerTwoContext.newPage();
 
   await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
+    playerOnePage.goto(`${CLIENT_BASE_URL}/?roomId=${roomId}&playerId=player-1`),
+    playerTwoPage.goto(`${CLIENT_BASE_URL}/?roomId=${roomId}&playerId=player-2`)
   ]);
 
   await expectHeroMoveSpent(playerOnePage, 0, "player-1");

--- a/tests/e2e/pvp-matchmaking-lifecycle.spec.ts
+++ b/tests/e2e/pvp-matchmaking-lifecycle.spec.ts
@@ -7,8 +7,7 @@ import {
   resolveBattleToSettlement,
   startDeterministicPvpBattle
 } from "./smoke-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {

--- a/tests/e2e/runtime-targets.ts
+++ b/tests/e2e/runtime-targets.ts
@@ -1,0 +1,25 @@
+const DEFAULT_SERVER_HOST = "127.0.0.1";
+const DEFAULT_CLIENT_HOST = "127.0.0.1";
+const DEFAULT_SERVER_PORT = 2567;
+const DEFAULT_CLIENT_PORT = 4173;
+
+function readPort(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export const SERVER_HOST = process.env.VEIL_PLAYWRIGHT_SERVER_HOST?.trim() || DEFAULT_SERVER_HOST;
+export const CLIENT_HOST = process.env.VEIL_PLAYWRIGHT_CLIENT_HOST?.trim() || DEFAULT_CLIENT_HOST;
+export const SERVER_PORT = readPort(process.env.VEIL_PLAYWRIGHT_SERVER_PORT, DEFAULT_SERVER_PORT);
+export const CLIENT_PORT = readPort(process.env.VEIL_PLAYWRIGHT_CLIENT_PORT, DEFAULT_CLIENT_PORT);
+
+export const SERVER_BASE_URL =
+  process.env.VEIL_PLAYWRIGHT_SERVER_ORIGIN?.trim() || `http://${SERVER_HOST}:${SERVER_PORT}`;
+export const SERVER_WS_URL =
+  process.env.VEIL_PLAYWRIGHT_SERVER_WS_URL?.trim() || `ws://${SERVER_HOST}:${SERVER_PORT}`;
+export const CLIENT_BASE_URL =
+  process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN?.trim() || `http://${CLIENT_HOST}:${CLIENT_PORT}`;
+export const ADMIN_BASE_URL = `${SERVER_BASE_URL}/admin`;
+export const ANALYTICS_CAPTURE_ENDPOINT = `${SERVER_BASE_URL}/api/test/analytics/events`;
+export const RESET_ENDPOINT = `${SERVER_BASE_URL}/api/test/reset-store`;
+export const SERVER_DIAGNOSTICS_URL = `${SERVER_BASE_URL}/api/runtime/diagnostic-snapshot?format=text`;

--- a/tests/e2e/seasonal-event-lifecycle.spec.ts
+++ b/tests/e2e/seasonal-event-lifecycle.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
 import { pollForAnalyticsEvent } from "./analytics-helpers";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token";
 const EVENT_ID = "defend-the-bridge";
 const OBJECTIVE_ACTION_TYPE = "daily_dungeon_reward_claimed";

--- a/tests/e2e/shop-purchase-settlement.spec.ts
+++ b/tests/e2e/shop-purchase-settlement.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-
-const SERVER_BASE_URL = "http://127.0.0.1:2567";
+import { SERVER_BASE_URL } from "./runtime-targets";
 const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token";
 const SEED_MESSAGE_ID = "shop-purchase-e2e-seed";
 const SEEDED_GEMS = 200;

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -1,8 +1,6 @@
 import { expect, test, type Page, type TestInfo } from "@playwright/test";
 import { getHeroMoveTotal } from "./config-fixtures";
-
-const CLIENT_BASE_URL = "http://127.0.0.1:4173";
-const SERVER_DIAGNOSTICS_URL = "http://127.0.0.1:2567/api/runtime/diagnostic-snapshot?format=text";
+import { CLIENT_BASE_URL, RESET_ENDPOINT, SERVER_DIAGNOSTICS_URL } from "./runtime-targets";
 
 interface RoomSessionOptions {
   roomId: string;
@@ -48,7 +46,7 @@ export function buildRoomId(prefix: string): string {
 }
 
 export async function resetSmokeStore(): Promise<void> {
-  const response = await fetch("http://127.0.0.1:2567/api/test/reset-store", {
+  const response = await fetch(RESET_ENDPOINT, {
     method: "POST"
   });
   if (!response.ok) {


### PR DESCRIPTION
## What changed
- route smoke/e2e helpers through shared runtime target helpers instead of fixed 127.0.0.1:2567/4173 endpoints
- update campaign and related smoke specs to consume the active Playwright-managed origins for API, websocket, analytics, and reset hooks

## Why
- the campaign mission replay guard failure in #1615 was caused by tests talking to the wrong runtime when multiple Playwright-managed servers were active
- this keeps the campaign flow pointed at the server/client pair that the current run actually started

## Validation
- npx playwright test tests/e2e/campaign-mission-flow.spec.ts --project=smoke --workers=1

Fixes #1615
