### PR TITLE
[codex] isolate playwright runtime state

### DIFF
--- a/apps/client/src/auth-session.ts
+++ b/apps/client/src/auth-session.ts
@@ -1,3 +1,5 @@
+import { resolveRuntimeServerHttpUrl } from "./runtime-targets";
+
 const AUTH_SESSION_STORAGE_KEY = "project-veil:auth-session";
 const AUTH_REQUEST_TIMEOUT_MS = 10000; // 延长到 10秒以适应开发环境
 
@@ -70,8 +72,7 @@ function getAuthSessionStorage(): Storage | null {
 }
 
 function resolveAuthApiBaseUrl(): string {
-  // 在 4173 开发环境下，强制指向 127.0.0.1:2567 以规避跨域解析问题
-  return `http://127.0.0.1:2567`;
+  return resolveRuntimeServerHttpUrl();
 }
 
 function createGuestPlayerId(): string {

--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -7,6 +7,7 @@ import type { BattleAction, BattleState, EquipmentType, MovementPlan, PlayerWorl
 import type { FeatureFlags } from "@veil/shared/platform";
 import type { ClientMessage, PlayerReportReason, ServerMessage, SessionStatePayload } from "@veil/shared/protocol";
 import type { RuntimeConfigBundle } from "@veil/shared/world";
+import { resolveRuntimeServerWsUrl } from "./runtime-targets";
 
 export interface SessionUpdate {
   world: PlayerWorldView;
@@ -946,8 +947,7 @@ async function connectRemoteGameSession(
   options?: GameSessionOptions,
   connectOptions?: RemoteConnectOptions
 ): Promise<RemoteConnectResult> {
-  // 强制锁定 127.0.0.1:2567，规避 DNS 和 localhost IPv6 解析问题
-  const remoteUrl = "ws://127.0.0.1:2567";
+  const remoteUrl = resolveRuntimeServerWsUrl();
   
   const storage = getReconnectionStorage();
   const useStoredToken = connectOptions?.useStoredToken ?? true;

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -7,6 +7,7 @@ import { buildAchievementUiItems, createHeroAttributeBreakdown, createHeroProgre
 import type { PlayerReportReason } from "@veil/shared/protocol";
 import { getDefaultBattleSkillCatalog, predictPlayerWorldAction } from "@veil/shared/world";
 import { createGameSession, readStoredSessionReplay, type SessionUpdate } from "./local-session";
+import { resolveRuntimeServerHttpUrl } from "./runtime-targets";
 import { buildH5RuntimeDiagnosticsSnapshot } from "./runtime-diagnostics";
 import {
   buildingAsset,
@@ -72,15 +73,17 @@ import {
 } from "./room-feedback";
 import { createMainSessionRuntime } from "./main-session-runtime";
 
+const runtimeServerHttpUrl = resolveRuntimeServerHttpUrl();
+
 // 注入全局调试条
 const debugBar = document.createElement("div");
 debugBar.style.cssText = "position:fixed;top:0;left:0;right:0;background:rgba(0,0,0,0.8);color:#0f0;padding:4px 10px;z-index:9999;font-size:12px;pointer-events:none;font-family:monospace;";
 debugBar.id = "veil-debug-bar";
-debugBar.textContent = `Target API: http://127.0.0.1:2567 | Status: Initializing...`;
+debugBar.textContent = `Target API: ${runtimeServerHttpUrl} | Status: Initializing...`;
 document.body.appendChild(debugBar);
 
 function updateDebugStatus(msg: string, color = "#0f0") {
-    debugBar.textContent = `Target API: http://127.0.0.1:2567 | ${msg}`;
+    debugBar.textContent = `Target API: ${runtimeServerHttpUrl} | ${msg}`;
     debugBar.style.color = color;
 }
 

--- a/apps/client/src/runtime-targets.ts
+++ b/apps/client/src/runtime-targets.ts
@@ -1,0 +1,15 @@
+const DEFAULT_SERVER_HTTP_URL = "http://127.0.0.1:2567";
+const DEFAULT_SERVER_WS_URL = "ws://127.0.0.1:2567";
+
+function readRuntimeEnv(key: string): string | undefined {
+  const value = import.meta.env[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function resolveRuntimeServerHttpUrl(): string {
+  return readRuntimeEnv("VITE_VEIL_SERVER_HTTP_URL") ?? DEFAULT_SERVER_HTTP_URL;
+}
+
+export function resolveRuntimeServerWsUrl(): string {
+  return readRuntimeEnv("VITE_VEIL_SERVER_WS_URL") ?? DEFAULT_SERVER_WS_URL;
+}

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -1,6 +1,14 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
+function readPort(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+const clientPort = readPort("VEIL_PLAYWRIGHT_CLIENT_PORT", 4173);
+const serverHttpUrl = process.env.VEIL_DEV_SERVER_HTTP_URL?.trim() || "http://127.0.0.1:2567";
+
 export default defineConfig({
   root: resolve(__dirname),
   resolve: {
@@ -10,20 +18,22 @@ export default defineConfig({
   },
   preview: {
     host: "127.0.0.1",
-    port: 4173,
+    port: clientPort,
+    strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:2567",
+        target: serverHttpUrl,
         changeOrigin: true
       }
     }
   },
   server: {
     host: "0.0.0.0",
-    port: 4173,
+    port: clientPort,
+    strictPort: true,
     proxy: {
       "/api": {
-        target: "http://127.0.0.1:2567",
+        target: serverHttpUrl,
         changeOrigin: true
       }
     }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
 import { defineConfig, type Project, type ReporterDescription, type WebServerPlugin } from "@playwright/test";
 
 const DAILY_QUEST_SMOKE_ROTATIONS = JSON.stringify({
@@ -52,6 +54,48 @@ const DAILY_QUEST_SMOKE_ROTATIONS = JSON.stringify({
 
 type ProjectDefinition = Project & { name: string };
 
+const DEFAULT_SERVER_PORT = 2567;
+const DEFAULT_CLIENT_PORT = 4173;
+const DEFAULT_SERVER_HOST = "127.0.0.1";
+const DEFAULT_CLIENT_HOST = "127.0.0.1";
+
+function readPort(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function derivePort(base: number, span = 300): number {
+  const seed = process.env.VEIL_PLAYWRIGHT_WORKSPACE_SEED?.trim() || `${process.cwd()}:${process.pid}`;
+  const hash = createHash("sha1").update(seed).digest();
+  const offset = ((hash[0] << 8) | hash[1]) % span;
+  return base + offset;
+}
+
+function normalizeOrigin(value: string | undefined, fallbackHost: string, fallbackPort: number, protocol: "http" | "ws"): string {
+  return value?.trim() || `${protocol}://${fallbackHost}:${fallbackPort}`;
+}
+
+const serverPort = readPort(
+  "VEIL_PLAYWRIGHT_SERVER_PORT",
+  process.env.VEIL_PLAYWRIGHT_REUSE_SERVER === "1" ? DEFAULT_SERVER_PORT : derivePort(DEFAULT_SERVER_PORT)
+);
+const clientPort = readPort(
+  "VEIL_PLAYWRIGHT_CLIENT_PORT",
+  process.env.VEIL_PLAYWRIGHT_REUSE_SERVER === "1" ? DEFAULT_CLIENT_PORT : derivePort(DEFAULT_CLIENT_PORT)
+);
+const serverOrigin = normalizeOrigin(process.env.VEIL_PLAYWRIGHT_SERVER_ORIGIN, DEFAULT_SERVER_HOST, serverPort, "http");
+const serverWsOrigin = normalizeOrigin(process.env.VEIL_PLAYWRIGHT_SERVER_WS_URL, DEFAULT_SERVER_HOST, serverPort, "ws");
+const clientOrigin = normalizeOrigin(process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN, DEFAULT_CLIENT_HOST, clientPort, "http");
+const runId = process.env.VEIL_PLAYWRIGHT_RUN_ID?.trim() || `${path.basename(process.cwd())}-${process.pid}`;
+const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR?.trim() || path.join("test-results", runId);
+const playwrightReportDir = process.env.PLAYWRIGHT_HTML_REPORT?.trim() || path.join("playwright-report", runId);
+
+process.env.VEIL_PLAYWRIGHT_SERVER_PORT = String(serverPort);
+process.env.VEIL_PLAYWRIGHT_CLIENT_PORT = String(clientPort);
+process.env.VEIL_PLAYWRIGHT_SERVER_ORIGIN = serverOrigin;
+process.env.VEIL_PLAYWRIGHT_SERVER_WS_URL = serverWsOrigin;
+process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN = clientOrigin;
+
 const SMOKE_PROJECT_NAME = "smoke";
 const H5_CONNECTIVITY_PROJECT_NAME = "h5-connectivity";
 const MULTIPLAYER_PROJECT_NAME = "multiplayer";
@@ -61,7 +105,7 @@ const FULL_PROJECT_NAME = "full";
 
 const SHARED_REPORTER: ReporterDescription[] = [
   ["list"],
-  ["html", { open: "never" }]
+  ["html", { open: "never", outputFolder: playwrightReportDir }]
 ];
 
 const SMOKE_TEST_MATCH =
@@ -115,7 +159,7 @@ function shouldReuseServers(): boolean {
 
 function resolveClientCommand(): string {
   if (process.env.VEIL_PLAYWRIGHT_CLIENT_MODE === "preview") {
-    return "npx vite preview --config apps/client/vite.config.ts --host 127.0.0.1 --port 4173 --strictPort";
+    return `npx vite preview --config apps/client/vite.config.ts --host ${DEFAULT_CLIENT_HOST} --port ${clientPort} --strictPort`;
   }
   return "npm run dev -- client:h5";
 }
@@ -128,7 +172,8 @@ function createSharedWebServers(): WebServerPlugin[] {
       command: "npm run dev -- server",
       env: {
         ...process.env,
-        ANALYTICS_ENDPOINT: "http://127.0.0.1:2567/api/test/analytics/events",
+        PORT: String(serverPort),
+        ANALYTICS_ENDPOINT: `${serverOrigin}/api/test/analytics/events`,
         ANALYTICS_SINK: "http",
         VEIL_ADMIN_TOKEN: process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token",
         VEIL_DAILY_QUESTS_ENABLED: "1",
@@ -138,7 +183,7 @@ function createSharedWebServers(): WebServerPlugin[] {
         VEIL_RATE_LIMIT_HTTP_ADMIN_MAX: process.env.VEIL_RATE_LIMIT_HTTP_ADMIN_MAX ?? "200",
         VEIL_RATE_LIMIT_WS_ACTION_MAX: process.env.VEIL_RATE_LIMIT_WS_ACTION_MAX ?? "40"
       },
-      port: 2567,
+      port: serverPort,
       reuseExistingServer,
       stdout: "pipe",
       stderr: "pipe",
@@ -150,7 +195,14 @@ function createSharedWebServers(): WebServerPlugin[] {
     },
     {
       command: resolveClientCommand(),
-      port: 4173,
+      env: {
+        ...process.env,
+        VEIL_PLAYWRIGHT_CLIENT_PORT: String(clientPort),
+        VEIL_DEV_SERVER_HTTP_URL: serverOrigin,
+        VITE_VEIL_SERVER_HTTP_URL: serverOrigin,
+        VITE_VEIL_SERVER_WS_URL: serverWsOrigin
+      },
+      port: clientPort,
       reuseExistingServer,
       stdout: "pipe",
       stderr: "pipe",
@@ -165,11 +217,12 @@ function createSharedWebServers(): WebServerPlugin[] {
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  outputDir: playwrightOutputDir,
   timeout: 30_000,
   fullyParallel: false,
   reporter: SHARED_REPORTER,
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: clientOrigin,
     headless: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",


### PR DESCRIPTION
## What changed
- give each Playwright-managed runtime its own server port, client port, HTML report folder, and test-results folder
- pass the derived runtime origins through Vite and the H5 client so browser, websocket, and auth traffic stay on the same isolated server

## Why
- the timeout in #1616 was caused by concurrent Playwright runs sharing the same fixed ports and artifact paths
- that cross-run interference also contaminated replay persistence and could surface as wrong-status campaign responses in adjacent smoke runs

## Validation
- npx playwright test tests/e2e/battle-replay-smoke.spec.ts --project=multiplayer-smoke --workers=1
- concurrent repro check:
  - npx playwright test tests/e2e/campaign-mission-flow.spec.ts --project=smoke --workers=1
  - npx playwright test tests/e2e/battle-replay-smoke.spec.ts --project=multiplayer-smoke --workers=1

Fixes #1616
