### PR TITLE
[codex] fix runtime target env fallback

### DIFF
--- a/apps/client/src/runtime-targets.ts
+++ b/apps/client/src/runtime-targets.ts
@@ -2,7 +2,7 @@ const DEFAULT_SERVER_HTTP_URL = "http://127.0.0.1:2567";
 const DEFAULT_SERVER_WS_URL = "ws://127.0.0.1:2567";
 
 function readRuntimeEnv(key: string): string | undefined {
-  const value = import.meta.env[key];
+  const value = (import.meta as ImportMeta & { env?: Record<string, unknown> }).env?.[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 

--- a/apps/client/test/runtime-targets.test.ts
+++ b/apps/client/test/runtime-targets.test.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveRuntimeServerHttpUrl, resolveRuntimeServerWsUrl } from "../src/runtime-targets";
+
+test("runtime target helpers fall back to localhost defaults when import.meta.env is unavailable", () => {
+  assert.equal(resolveRuntimeServerHttpUrl(), "http://127.0.0.1:2567");
+  assert.equal(resolveRuntimeServerWsUrl(), "ws://127.0.0.1:2567");
+});


### PR DESCRIPTION
## What changed
- make H5 runtime target resolution tolerate Node test environments where `import.meta.env` is absent
- add a focused regression test that locks the localhost fallback behavior

## Why
- the recent runtime-target refactor assumed Vite-style `import.meta.env` always exists
- under Node-based client tests that assumption throws before auth/session helpers can execute, which broke 8 H5-facing unit tests and made `npm test` red on Node 22

## Validation
- npx -p node@22 node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/client/test/runtime-targets.test.ts ./apps/client/test/auth-privacy-consent.test.ts ./apps/client/test/auth-session-storage.test.ts ./apps/client/test/local-session.test.ts ./apps/client/test/main.test.ts
- npx -p node@22 npm test
