### PR TITLE
refactor: extract pure formatters from main.ts by claude (#1627)

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -72,6 +72,33 @@ import {
   resolveRoomFeedbackTone
 } from "./room-feedback";
 import { createMainSessionRuntime } from "./main-session-runtime";
+import {
+  clampWorldCoordinate,
+  diagnosticsConnectionStatusLabel,
+  escapeHtml,
+  formatAccountBindingCta,
+  formatAccountLastSeen,
+  formatAccountSource,
+  formatAuthModeLabel,
+  formatCredentialBinding,
+  formatDailyIncome,
+  formatEquipmentActionReason,
+  formatExperimentAuditLabel,
+  formatGlobalVault,
+  formatHeroCoreStats,
+  formatHeroExperience,
+  formatHeroProgression,
+  formatHeroSkillReason,
+  formatHeroStatBonus,
+  formatLobbyRoomUpdatedAt,
+  formatPath,
+  formatRelativeSessionTimestamp,
+  formatResourceKindLabel,
+  formatSessionProviderLabel,
+  resolveExperimentVariant,
+  sanitizeSnapshotFileSegment,
+  tileLabel
+} from "./main/formatters";
 
 const runtimeServerHttpUrl = resolveRuntimeServerHttpUrl();
 
@@ -476,22 +503,6 @@ let sessionPromise: ReturnType<typeof createGameSession> | null = shouldBootGame
     })
   : null;
 
-function diagnosticsConnectionStatusLabel(status: RuntimeDiagnosticsConnectionStatus): string {
-  if (status === "connected") {
-    return "已连接";
-  }
-
-  if (status === "reconnecting") {
-    return "重连中";
-  }
-
-  if (status === "reconnect_failed") {
-    return "恢复失败";
-  }
-
-  return "连接中";
-}
-
 function buildDiagnosticSnapshot() {
   const hero = activeHero();
 
@@ -556,11 +567,6 @@ function exportDiagnosticSnapshot(): string {
 
 function renderDiagnosticSnapshotToText(): string {
   return renderRuntimeDiagnosticsSnapshotText(buildDiagnosticSnapshot());
-}
-
-function sanitizeSnapshotFileSegment(value: string): string {
-  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
-  return normalized || "unknown";
 }
 
 function triggerDiagnosticSnapshotExport(): void {
@@ -842,96 +848,6 @@ function flushUiTasksThrough(targetMs: number): void {
   }
 
   uiClockMs = safeTargetMs;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-function formatAccountSource(account: ClientPlayerAccountProfile): string {
-  return account.source === "remote" ? "云端账号" : "本地游客档";
-}
-
-function formatAuthModeLabel(session: StoredAuthSession | null): string {
-  if (!session) {
-    return "未登录";
-  }
-
-  if (session.authMode === "account") {
-    return session.loginId ? `账号模式 · ${session.loginId}` : "账号模式";
-  }
-
-  return "游客模式";
-}
-
-function formatCredentialBinding(account: ClientPlayerAccountProfile): string {
-  if (!account.loginId) {
-    return "尚未绑定口令账号，可把当前游客档升级成长期账号。";
-  }
-
-  if (!account.credentialBoundAt) {
-    return `已绑定登录 ID：${account.loginId}`;
-  }
-
-  const date = new Date(account.credentialBoundAt);
-  const label = Number.isNaN(date.getTime()) ? account.credentialBoundAt : date.toLocaleString();
-  return `已绑定登录 ID：${account.loginId} · ${label}`;
-}
-
-function formatAccountLastSeen(account: ClientPlayerAccountProfile): string {
-  if (!account.lastSeenAt) {
-    return account.lastRoomId ? `最近房间 ${account.lastRoomId}` : "尚未记录活跃时间";
-  }
-
-  const date = new Date(account.lastSeenAt);
-  const label = Number.isNaN(date.getTime()) ? account.lastSeenAt : date.toLocaleString();
-  return account.lastRoomId ? `${label} · ${account.lastRoomId}` : label;
-}
-
-function formatGlobalVault(account: ClientPlayerAccountProfile): string {
-  return `全局仓库 金币 ${account.globalResources.gold} / 木材 ${account.globalResources.wood} / 矿石 ${account.globalResources.ore}`;
-}
-
-function resolveExperimentVariant(account: ClientPlayerAccountProfile, experimentKey: string): string | null {
-  return account.experiments?.find((experiment) => experiment.experimentKey === experimentKey)?.variant ?? null;
-}
-
-function formatExperimentAuditLabel(account: ClientPlayerAccountProfile): string | null {
-  const experiment = account.experiments?.find((entry) => entry.experimentKey === "account_portal_copy");
-  if (!experiment) {
-    return null;
-  }
-
-  return `${experiment.experimentName} · ${experiment.variant} · bucket ${experiment.bucket} · owner ${experiment.owner}`;
-}
-
-function formatAccountBindingCta(account: ClientPlayerAccountProfile): string {
-  if (account.loginId) {
-    return "当前档案已可用登录 ID 直接进入";
-  }
-
-  return resolveExperimentVariant(account, "account_portal_copy") === "upgrade"
-    ? "绑定口令账号，保留当前游客档进度、成就和战报，并支持后续多设备继续。"
-    : "把当前游客档升级成可长期登录的账号";
-}
-
-function formatRelativeSessionTimestamp(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
-}
-
-function formatSessionProviderLabel(provider: string): string {
-  if (provider === "wechat-mini-game") {
-    return "微信小游戏";
-  }
-  if (provider === "account-password") {
-    return "口令登录";
-  }
-  return provider;
 }
 
 function renderAccountSessionPanel(): string {
@@ -1229,23 +1145,6 @@ function applyReplayPlaybackControl(action: "play" | "pause" | "step" | "reset")
   render();
 }
 
-function formatLobbyRoomUpdatedAt(updatedAt: string): string {
-  const date = new Date(updatedAt);
-  return Number.isNaN(date.getTime()) ? updatedAt : date.toLocaleString();
-}
-
-function tileLabel(tile: PlayerTileView): string {
-  if (tile.fog === "hidden") {
-    return "?";
-  }
-
-  const terrain = tile.terrain.slice(0, 1).toUpperCase();
-  const occupant = tile.occupant?.kind === "neutral" ? "M" : tile.occupant?.kind === "hero" ? "H" : "";
-  const resource = tile.resource ? tile.resource.kind.slice(0, 1).toUpperCase() : "";
-  const building = tile.building ? "B" : "";
-  return `${terrain}${occupant}${resource}${building}`;
-}
-
 function markerStateForTile(tile: PlayerTileView): "idle" | "selected" | "hit" {
   if (tile.occupant?.refId && state.battleFx.flashUnitId && state.battleFx.flashUnitId.startsWith(tile.occupant.refId)) {
     return "hit";
@@ -1283,29 +1182,8 @@ function renderTileMedia(tile: PlayerTileView): string {
   `;
 }
 
-function formatPath(path: { x: number; y: number }[]): string {
-  return path.map((node) => `(${node.x},${node.y})`).join(" -> ");
-}
-
 function activeHero() {
   return state.selectedHeroId ? state.world.ownHeroes.find((item) => item.id === state.selectedHeroId) ?? null : null;
-}
-
-function formatHeroProgression(hero: PlayerWorldView["ownHeroes"][number] | null): string {
-  if (!hero) {
-    return "Lv 0";
-  }
-
-  return `Lv ${hero.progression.level}`;
-}
-
-function formatHeroExperience(hero: PlayerWorldView["ownHeroes"][number] | null): string {
-  if (!hero) {
-    return "XP 0/100";
-  }
-
-  const meter = createHeroProgressMeterView(hero);
-  return `XP ${meter.currentLevelExperience}/${meter.nextLevelExperience}`;
 }
 
 function renderHeroProgressPanel(hero: PlayerWorldView["ownHeroes"][number] | null): string {
@@ -1374,30 +1252,6 @@ function renderHeroAttributePanel(
       </div>
     </section>
   `;
-}
-
-function formatEquipmentActionReason(reason: string): string {
-  if (reason === "equipment_not_in_inventory") {
-    return "背包里没有这件装备";
-  }
-
-  if (reason === "equipment_slot_mismatch") {
-    return "装备类型和槽位不匹配";
-  }
-
-  if (reason === "equipment_definition_missing") {
-    return "装备目录缺失，无法装备";
-  }
-
-  if (reason === "equipment_slot_empty") {
-    return "当前槽位没有可卸下的装备";
-  }
-
-  if (reason === "equipment_already_equipped") {
-    return "该装备已经穿戴中";
-  }
-
-  return reason;
 }
 
 function inventoryItemsForSlot(
@@ -1516,26 +1370,6 @@ function renderHeroEquipmentPanel(hero: PlayerWorldView["ownHeroes"][number] | n
   `;
 }
 
-function formatHeroSkillReason(reason: string): string {
-  if (reason === "not_enough_skill_points") {
-    return "需要可用技能点";
-  }
-
-  if (reason === "hero_level_too_low") {
-    return "等级未达标";
-  }
-
-  if (reason === "skill_max_rank_reached") {
-    return "已满级";
-  }
-
-  if (reason === "skill_prerequisite_missing") {
-    return "前置未满足";
-  }
-
-  return reason;
-}
-
 function formatGrantedBattleSkillNames(skillIds: string[]): string {
   if (skillIds.length === 0) {
     return "当前未提供额外战斗技能";
@@ -1613,33 +1447,6 @@ function renderHeroSkillTree(hero: PlayerWorldView["ownHeroes"][number] | null):
   `;
 }
 
-function formatResourceKindLabel(kind: "gold" | "wood" | "ore"): string {
-  return kind === "gold" ? "金币" : kind === "wood" ? "木材" : "矿石";
-}
-
-function formatDailyIncome(kind: "gold" | "wood" | "ore", amount: number): string {
-  return `${formatResourceKindLabel(kind)} +${amount}/天`;
-}
-
-function formatHeroCoreStats(hero: PlayerWorldView["ownHeroes"][number] | null): string {
-  if (!hero) {
-    return "ATK 0 · DEF 0 · POW 0 · KNW 0";
-  }
-
-  return `ATK ${hero.stats.attack} · DEF ${hero.stats.defense} · POW ${hero.stats.power} · KNW ${hero.stats.knowledge}`;
-}
-
-function formatHeroStatBonus(bonus: { attack: number; defense: number; power: number; knowledge: number }): string {
-  const parts = [
-    bonus.attack > 0 ? `攻击 +${bonus.attack}` : "",
-    bonus.defense > 0 ? `防御 +${bonus.defense}` : "",
-    bonus.power > 0 ? `力量 +${bonus.power}` : "",
-    bonus.knowledge > 0 ? `知识 +${bonus.knowledge}` : ""
-  ].filter(Boolean);
-
-  return parts.join(" / ") || "属性提升";
-}
-
 function hoveredTileData(): PlayerTileView | null {
   if (!state.hoveredTile) {
     return null;
@@ -1650,14 +1457,6 @@ function hoveredTileData(): PlayerTileView | null {
       (tile) => tile.position.x === state.hoveredTile!.x && tile.position.y === state.hoveredTile!.y
     ) ?? null
   );
-}
-
-function clampWorldCoordinate(value: number, limit: number): number {
-  if (limit <= 0) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(limit - 1, Math.floor(value)));
 }
 
 function clampWorldPosition(x: number, y: number): { x: number; y: number } {

--- a/apps/client/src/main/formatters.ts
+++ b/apps/client/src/main/formatters.ts
@@ -1,0 +1,241 @@
+import type { PlayerTileView, PlayerWorldView } from "@veil/shared/models";
+import type { RuntimeDiagnosticsConnectionStatus } from "@veil/shared/platform";
+import { createHeroProgressMeterView } from "@veil/shared/progression";
+import type { StoredAuthSession } from "../auth-session";
+import type { PlayerAccountProfile as ClientPlayerAccountProfile } from "../player-account";
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function formatAccountSource(account: ClientPlayerAccountProfile): string {
+  return account.source === "remote" ? "云端账号" : "本地游客档";
+}
+
+export function formatAuthModeLabel(session: StoredAuthSession | null): string {
+  if (!session) {
+    return "未登录";
+  }
+
+  if (session.authMode === "account") {
+    return session.loginId ? `账号模式 · ${session.loginId}` : "账号模式";
+  }
+
+  return "游客模式";
+}
+
+export function formatCredentialBinding(account: ClientPlayerAccountProfile): string {
+  if (!account.loginId) {
+    return "尚未绑定口令账号，可把当前游客档升级成长期账号。";
+  }
+
+  if (!account.credentialBoundAt) {
+    return `已绑定登录 ID：${account.loginId}`;
+  }
+
+  const date = new Date(account.credentialBoundAt);
+  const label = Number.isNaN(date.getTime()) ? account.credentialBoundAt : date.toLocaleString();
+  return `已绑定登录 ID：${account.loginId} · ${label}`;
+}
+
+export function formatAccountLastSeen(account: ClientPlayerAccountProfile): string {
+  if (!account.lastSeenAt) {
+    return account.lastRoomId ? `最近房间 ${account.lastRoomId}` : "尚未记录活跃时间";
+  }
+
+  const date = new Date(account.lastSeenAt);
+  const label = Number.isNaN(date.getTime()) ? account.lastSeenAt : date.toLocaleString();
+  return account.lastRoomId ? `${label} · ${account.lastRoomId}` : label;
+}
+
+export function formatGlobalVault(account: ClientPlayerAccountProfile): string {
+  return `全局仓库 金币 ${account.globalResources.gold} / 木材 ${account.globalResources.wood} / 矿石 ${account.globalResources.ore}`;
+}
+
+export function resolveExperimentVariant(
+  account: ClientPlayerAccountProfile,
+  experimentKey: string
+): string | null {
+  return account.experiments?.find((experiment) => experiment.experimentKey === experimentKey)?.variant ?? null;
+}
+
+export function formatExperimentAuditLabel(account: ClientPlayerAccountProfile): string | null {
+  const experiment = account.experiments?.find((entry) => entry.experimentKey === "account_portal_copy");
+  if (!experiment) {
+    return null;
+  }
+
+  return `${experiment.experimentName} · ${experiment.variant} · bucket ${experiment.bucket} · owner ${experiment.owner}`;
+}
+
+export function formatAccountBindingCta(account: ClientPlayerAccountProfile): string {
+  if (account.loginId) {
+    return "当前档案已可用登录 ID 直接进入";
+  }
+
+  return resolveExperimentVariant(account, "account_portal_copy") === "upgrade"
+    ? "绑定口令账号，保留当前游客档进度、成就和战报，并支持后续多设备继续。"
+    : "把当前游客档升级成可长期登录的账号";
+}
+
+export function formatRelativeSessionTimestamp(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export function formatSessionProviderLabel(provider: string): string {
+  if (provider === "wechat-mini-game") {
+    return "微信小游戏";
+  }
+  if (provider === "account-password") {
+    return "口令登录";
+  }
+  return provider;
+}
+
+export function formatLobbyRoomUpdatedAt(updatedAt: string): string {
+  const date = new Date(updatedAt);
+  return Number.isNaN(date.getTime()) ? updatedAt : date.toLocaleString();
+}
+
+export function tileLabel(tile: PlayerTileView): string {
+  if (tile.fog === "hidden") {
+    return "?";
+  }
+
+  const terrain = tile.terrain.slice(0, 1).toUpperCase();
+  const occupant = tile.occupant?.kind === "neutral" ? "M" : tile.occupant?.kind === "hero" ? "H" : "";
+  const resource = tile.resource ? tile.resource.kind.slice(0, 1).toUpperCase() : "";
+  const building = tile.building ? "B" : "";
+  return `${terrain}${occupant}${resource}${building}`;
+}
+
+export function formatPath(path: { x: number; y: number }[]): string {
+  return path.map((node) => `(${node.x},${node.y})`).join(" -> ");
+}
+
+export function formatHeroProgression(hero: PlayerWorldView["ownHeroes"][number] | null): string {
+  if (!hero) {
+    return "Lv 0";
+  }
+
+  return `Lv ${hero.progression.level}`;
+}
+
+export function formatHeroExperience(hero: PlayerWorldView["ownHeroes"][number] | null): string {
+  if (!hero) {
+    return "XP 0/100";
+  }
+
+  const meter = createHeroProgressMeterView(hero);
+  return `XP ${meter.currentLevelExperience}/${meter.nextLevelExperience}`;
+}
+
+export function formatResourceKindLabel(kind: "gold" | "wood" | "ore"): string {
+  return kind === "gold" ? "金币" : kind === "wood" ? "木材" : "矿石";
+}
+
+export function formatDailyIncome(kind: "gold" | "wood" | "ore", amount: number): string {
+  return `${formatResourceKindLabel(kind)} +${amount}/天`;
+}
+
+export function formatHeroCoreStats(hero: PlayerWorldView["ownHeroes"][number] | null): string {
+  if (!hero) {
+    return "ATK 0 · DEF 0 · POW 0 · KNW 0";
+  }
+
+  return `ATK ${hero.stats.attack} · DEF ${hero.stats.defense} · POW ${hero.stats.power} · KNW ${hero.stats.knowledge}`;
+}
+
+export function formatHeroStatBonus(bonus: {
+  attack: number;
+  defense: number;
+  power: number;
+  knowledge: number;
+}): string {
+  const parts = [
+    bonus.attack > 0 ? `攻击 +${bonus.attack}` : "",
+    bonus.defense > 0 ? `防御 +${bonus.defense}` : "",
+    bonus.power > 0 ? `力量 +${bonus.power}` : "",
+    bonus.knowledge > 0 ? `知识 +${bonus.knowledge}` : ""
+  ].filter(Boolean);
+
+  return parts.join(" / ") || "属性提升";
+}
+
+export function formatEquipmentActionReason(reason: string): string {
+  if (reason === "equipment_not_in_inventory") {
+    return "背包里没有这件装备";
+  }
+
+  if (reason === "equipment_slot_mismatch") {
+    return "装备类型和槽位不匹配";
+  }
+
+  if (reason === "equipment_definition_missing") {
+    return "装备目录缺失，无法装备";
+  }
+
+  if (reason === "equipment_slot_empty") {
+    return "当前槽位没有可卸下的装备";
+  }
+
+  if (reason === "equipment_already_equipped") {
+    return "该装备已经穿戴中";
+  }
+
+  return reason;
+}
+
+export function formatHeroSkillReason(reason: string): string {
+  if (reason === "not_enough_skill_points") {
+    return "需要可用技能点";
+  }
+
+  if (reason === "hero_level_too_low") {
+    return "等级未达标";
+  }
+
+  if (reason === "skill_max_rank_reached") {
+    return "已满级";
+  }
+
+  if (reason === "skill_prerequisite_missing") {
+    return "前置未满足";
+  }
+
+  return reason;
+}
+
+export function clampWorldCoordinate(value: number, limit: number): number {
+  if (limit <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(limit - 1, Math.floor(value)));
+}
+
+export function diagnosticsConnectionStatusLabel(status: RuntimeDiagnosticsConnectionStatus): string {
+  if (status === "connected") {
+    return "已连接";
+  }
+
+  if (status === "reconnecting") {
+    return "重连中";
+  }
+
+  if (status === "reconnect_failed") {
+    return "恢复失败";
+  }
+
+  return "连接中";
+}
+
+export function sanitizeSnapshotFileSegment(value: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  return normalized || "unknown";
+}


### PR DESCRIPTION
## Summary
- Pull 25 pure helpers (escapeHtml, account/session labels, hero stats, tile/path labels, diagnostics, etc.) out of apps/client/src/main.ts into a new apps/client/src/main/formatters.ts module.
- main.ts drops from 5875 → 5674 lines; the new module is 241 lines.
- First slice of the #1627 split plan — formatters are pure (no state, no DOM, no async) so they're the lowest-risk prefix to extract.

## Test plan
- [x] `npm run typecheck -- client` — clean
- [x] apps/client main tests (`main.test.ts`, `main-boot.test.ts`, `main-entry.test.ts`, `main-bootstrap-launch.test.ts`, `main-launch.test.ts`, `main-session-runtime.test.ts`) — 18/18 pass
- [x] `npm run lint:arch` — no new violations vs. baseline (1 pre-existing server-domain-no-transport error, 29 pre-existing circular warnings, all unrelated to this change)

Closes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)