### PR TITLE
fix: harden k8s runtime manifests

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -22,6 +22,8 @@ ENV npm_config_update_notifier=false
 ENV HOST=0.0.0.0
 ENV PORT=2567
 ENV VEIL_MIGRATIONS_PATH=/app/dist/scripts/migrations
+ENV HOME=/tmp
+ENV TMPDIR=/tmp
 
 COPY package.json package-lock.json ./
 COPY apps/client/package.json ./apps/client/package.json
@@ -35,9 +37,16 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/configs ./configs
 COPY --from=build /app/apps/client/admin.html ./apps/client/admin.html
 
+RUN groupadd -r --gid 10001 veil \
+  && useradd -r --uid 10001 --gid veil veil \
+  && mkdir -p /tmp \
+  && chown -R veil:veil /app /tmp
+
 EXPOSE 2567
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
   CMD node -e "fetch('http://127.0.0.1:2567/api/runtime/health').then((res) => { if (!res.ok) process.exit(1); }).catch(() => process.exit(1));"
+
+USER 10001:10001
 
 CMD ["node", "./dist/server/server.mjs"]

--- a/docs/ops/production-deploy-runbook.md
+++ b/docs/ops/production-deploy-runbook.md
@@ -26,18 +26,19 @@ Before widening traffic after a deploy, check [`docs/ops/capacity-planning.md`](
 
 1. Start from the release commit you plan to deploy and record its git SHA plus intended image tag.
 2. Copy `ops/env/production.env.example` to `ops/env/production.env` on the host and fill in the non-sensitive values plus the Secrets Manager bootstrap settings.
-3. Confirm the AWS IAM role or instance profile attached to the host can call `secretsmanager:GetSecretValue` on the configured secret.
-4. Confirm the AWS secret payload includes every key listed in [`docs/ops/secrets-inventory.md`](./secrets-inventory.md).
-5. Confirm `SENTRY_DSN` is present in `ops/env/production.env`; production startup now warns loudly when external error delivery is disabled.
-6. If this deploy should emit analytics events externally, confirm `ANALYTICS_SINK=http` is set in the runtime secret bundle and `ANALYTICS_ENDPOINT` is present in `ops/env/production.env`.
-7. Run `npm run validate -- production-env -- --env-file ops/env/production.env`.
-8. Confirm MySQL resolves from the deploy host:
+3. For the Compose production path, export or write `MYSQL_ROOT_PASSWORD` before any `docker compose -f docker-compose.prod.yml` command. The production compose file now fails fast when that variable is missing.
+4. Confirm the AWS IAM role or instance profile attached to the host can call `secretsmanager:GetSecretValue` on the configured secret.
+5. Confirm the AWS secret payload includes every key listed in [`docs/ops/secrets-inventory.md`](./secrets-inventory.md).
+6. Confirm `SENTRY_DSN` is present in `ops/env/production.env`; production startup now warns loudly when external error delivery is disabled.
+7. If this deploy should emit analytics events externally, confirm `ANALYTICS_SINK=http` is set in the runtime secret bundle and `ANALYTICS_ENDPOINT` is present in `ops/env/production.env`.
+8. Run `npm run validate -- production-env -- --env-file ops/env/production.env`.
+9. Confirm MySQL resolves from the deploy host:
    `docker compose -f docker-compose.prod.yml --env-file ops/env/production.env run --rm migrate`
-9. Confirm Redis resolves from the deploy host:
+10. Confirm Redis resolves from the deploy host:
    `docker compose -f docker-compose.prod.yml --env-file ops/env/production.env run --rm server node --input-type=module -e "const Redis=(await import('ioredis')).default; const url=process.env.REDIS_URL||'redis://redis:6379/0'; const client=new Redis(url); console.log(await client.ping(), url); await client.quit();"`
-10. Review disk headroom for the persistent volumes used by MySQL and Redis.
-11. Confirm you have the previous image tag and previous git SHA available for rollback.
-12. Schedule the deploy in a low-traffic window and verify no active incident or schema-restore work is in progress.
+11. Review disk headroom for the persistent volumes used by MySQL and Redis.
+12. Confirm you have the previous image tag and previous git SHA available for rollback.
+13. Schedule the deploy in a low-traffic window and verify no active incident or schema-restore work is in progress.
 
 ## 3. Production Env Contract
 
@@ -52,6 +53,7 @@ Notes:
 - `SENTRY_DSN` should always be set for production deploys. Startup does not hard-fail without it, but it now emits a prominent warning because runtime errors will stay local-only.
 - `ANALYTICS_ENDPOINT` is required by the validator even if the runtime secret currently leaves `ANALYTICS_SINK=stdout`; use the production ingest URL so switching delivery back on does not require an emergency env-file edit.
 - Keep credentials out of `ops/env/production.env`; place them in the AWS secret JSON documented in [`docs/ops/secrets-inventory.md`](./secrets-inventory.md).
+- `MYSQL_ROOT_PASSWORD` is the one Compose-only exception: it is required for the local MySQL service in `docker-compose.prod.yml` and must be pre-supplied via the deploy host environment or env-file workflow before Compose starts.
 - If you use managed MySQL or Redis, point `VEIL_MYSQL_HOST` and `REDIS_URL` at those services and leave the local `mysql` / `redis` services disabled by policy or removed in an override file.
 
 ## 4. First-Time Host Bootstrap

--- a/docs/ops/secrets-inventory.md
+++ b/docs/ops/secrets-inventory.md
@@ -32,6 +32,10 @@ Non-sensitive values stay in env vars:
 - Public identifiers such as `WECHAT_APP_ID`, `VEIL_WECHAT_PAY_APP_ID`, merchant ids, notify URLs, certificate serials, `VEIL_APNS_KEY_ID`, `VEIL_APNS_TEAM_ID`, `VEIL_APNS_TOPIC`, `VEIL_APNS_HOST`
 - Mobile push routing knobs such as `VEIL_APNS_USE_SANDBOX` and `VEIL_FCM_SEND_URL`
 
+Compose-only local secret:
+
+- `MYSQL_ROOT_PASSWORD` is required by `docker-compose.prod.yml` whenever the in-stack MySQL service is used. Do not commit it to the repo; provide it through the deploy host environment or a host-local env file before running the production Compose stack.
+
 Additional sensitive mobile-push secrets belong in the same secret bundle:
 
 | Key | Used by | Purpose | Rotation |

--- a/k8s/canary/deployment-canary.yaml
+++ b/k8s/canary/deployment-canary.yaml
@@ -16,6 +16,16 @@ spec:
         app.kubernetes.io/track: canary
     spec:
       terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: server
           image: ghcr.io/dannagrace/projectveil-server:v0.0.0
@@ -34,6 +44,25 @@ spec:
           ports:
             - name: http
               containerPort: 2567
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 20"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           readinessProbe:
             httpGet:
               path: /api/runtime/health
@@ -42,3 +71,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/runtime/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 4

--- a/k8s/canary/deployment-stable.yaml
+++ b/k8s/canary/deployment-stable.yaml
@@ -16,6 +16,16 @@ spec:
         app.kubernetes.io/track: stable
     spec:
       terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: server
           image: ghcr.io/dannagrace/projectveil-server:v0.0.0
@@ -34,6 +44,25 @@ spec:
           ports:
             - name: http
               containerPort: 2567
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 20"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
           readinessProbe:
             httpGet:
               path: /api/runtime/health
@@ -42,3 +71,11 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/runtime/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 4

--- a/k8s/canary/kustomization.yaml
+++ b/k8s/canary/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - service-stable.yaml
   - service-canary.yaml
   - ingress-canary.yaml
+  - pdb.yaml
+  - network-policy.yaml
 images:
   - name: ghcr.io/dannagrace/projectveil-server
     newTag: v0.0.0

--- a/k8s/canary/network-policy.yaml
+++ b/k8s/canary/network-policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: project-veil-server
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: project-veil-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 2567
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: project-veil
+      ports:
+        - protocol: TCP
+          port: 6379
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 3306
+        - protocol: TCP
+          port: 443

--- a/k8s/canary/pdb.yaml
+++ b/k8s/canary/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: project-veil-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: project-veil-server

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,6 +14,16 @@ spec:
         app.kubernetes.io/name: project-veil-server
     spec:
       terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: server
           image: ghcr.io/dannagrace/projectveil-server:v0.0.0
@@ -32,6 +42,18 @@ spec:
           ports:
             - name: http
               containerPort: 2567
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 20"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests:
               cpu: 500m

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - service.yaml
   - ingress.yaml
   - hpa.yaml
+  - pdb.yaml
+  - network-policy.yaml
 images:
   - name: ghcr.io/dannagrace/projectveil-server
     newTag: v0.0.0

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: project-veil
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: project-veil-server
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: project-veil-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 2567
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: project-veil
+      ports:
+        - protocol: TCP
+          port: 6379
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 3306
+        - protocol: TCP
+          port: 443

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: project-veil-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: project-veil-server

--- a/scripts/test/k8s-runtime-hardening.test.ts
+++ b/scripts/test/k8s-runtime-hardening.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(resolve(repoRoot, relativePath), "utf8");
+}
+
+function assertDeploymentHardening(manifest: string): void {
+  assert.match(manifest, /terminationGracePeriodSeconds:\s*60/);
+  assert.match(manifest, /runAsNonRoot:\s*true/);
+  assert.match(manifest, /runAsUser:\s*10001/);
+  assert.match(manifest, /fsGroup:\s*10001/);
+  assert.match(manifest, /seccompProfile:\s*\n\s*type:\s*RuntimeDefault/);
+  assert.match(manifest, /emptyDir:\s*\{\}/);
+  assert.match(manifest, /mountPath:\s*\/tmp/);
+  assert.match(manifest, /preStop:\s*\n\s*exec:\s*\n\s*command:\s*\["\/bin\/sh", "-c", "sleep 20"\]/);
+  assert.match(manifest, /allowPrivilegeEscalation:\s*false/);
+  assert.match(manifest, /readOnlyRootFilesystem:\s*true/);
+  assert.match(manifest, /drop:\s*\["ALL"\]/);
+}
+
+function assertProbeAndResources(manifest: string): void {
+  assert.match(manifest, /resources:\s*\n\s*requests:\s*\n\s*cpu:\s*500m\s*\n\s*memory:\s*512Mi/);
+  assert.match(manifest, /limits:\s*\n\s*cpu:\s*"1"\s*\n\s*memory:\s*1Gi/);
+  assert.match(manifest, /livenessProbe:\s*\n\s*httpGet:\s*\n\s*path:\s*\/api\/runtime\/health\s*\n\s*port:\s*http/);
+}
+
+test("runtime Dockerfile runs as a non-root veil user", async () => {
+  const dockerfile = await readRepoFile("Dockerfile.server");
+
+  assert.match(dockerfile, /groupadd -r --gid 10001 veil/);
+  assert.match(dockerfile, /useradd -r --uid 10001 --gid veil veil/);
+  assert.match(dockerfile, /ENV HOME=\/tmp/);
+  assert.match(dockerfile, /USER 10001:10001/);
+});
+
+test("deployments apply runtime hardening controls", async () => {
+  const [primary, canary, stable] = await Promise.all([
+    readRepoFile("k8s/deployment.yaml"),
+    readRepoFile("k8s/canary/deployment-canary.yaml"),
+    readRepoFile("k8s/canary/deployment-stable.yaml")
+  ]);
+
+  assertDeploymentHardening(primary);
+  assertDeploymentHardening(canary);
+  assertDeploymentHardening(stable);
+  assertProbeAndResources(primary);
+  assertProbeAndResources(canary);
+  assertProbeAndResources(stable);
+});
+
+test("namespace and kustomizations include restricted pod security, PDB, and NetworkPolicy", async () => {
+  const [namespaceYaml, rootKustomization, canaryKustomization] = await Promise.all([
+    readRepoFile("k8s/namespace.yaml"),
+    readRepoFile("k8s/kustomization.yaml"),
+    readRepoFile("k8s/canary/kustomization.yaml")
+  ]);
+
+  assert.match(namespaceYaml, /pod-security\.kubernetes\.io\/enforce:\s*restricted/);
+  assert.match(namespaceYaml, /pod-security\.kubernetes\.io\/audit:\s*restricted/);
+  assert.match(rootKustomization, /- pdb\.yaml/);
+  assert.match(rootKustomization, /- network-policy\.yaml/);
+  assert.match(canaryKustomization, /- pdb\.yaml/);
+  assert.match(canaryKustomization, /- network-policy\.yaml/);
+});
+
+test("network policy restricts ingress to ingress-nginx and narrows egress", async () => {
+  const [rootPolicy, canaryPolicy] = await Promise.all([
+    readRepoFile("k8s/network-policy.yaml"),
+    readRepoFile("k8s/canary/network-policy.yaml")
+  ]);
+
+  for (const policy of [rootPolicy, canaryPolicy]) {
+    assert.match(policy, /kind:\s*NetworkPolicy/);
+    assert.match(policy, /kubernetes\.io\/metadata\.name:\s*ingress-nginx/);
+    assert.match(policy, /port:\s*2567/);
+    assert.match(policy, /kubernetes\.io\/metadata\.name:\s*kube-system/);
+    assert.match(policy, /port:\s*6379/);
+    assert.match(policy, /port:\s*3306/);
+    assert.match(policy, /port:\s*443/);
+  }
+});
+
+test("production runbook and secrets inventory document compose MYSQL_ROOT_PASSWORD requirements", async () => {
+  const [runbook, secretsInventory] = await Promise.all([
+    readRepoFile("docs/ops/production-deploy-runbook.md"),
+    readRepoFile("docs/ops/secrets-inventory.md")
+  ]);
+
+  assert.match(runbook, /MYSQL_ROOT_PASSWORD/);
+  assert.match(runbook, /fails fast when that variable is missing/);
+  assert.match(secretsInventory, /Compose-only local secret:/);
+  assert.match(secretsInventory, /MYSQL_ROOT_PASSWORD/);
+});


### PR DESCRIPTION
## Summary
- run the server container as a non-root user and add restricted pod security controls
- add preStop drain delay, PodDisruptionBudget, and NetworkPolicy to both top-level and canary kustomizations
- bring canary and stable deployments back in sync with livenessProbe/resources and document the compose MYSQL_ROOT_PASSWORD requirement

## Issues
- Fixes #1623
- Fixes #1626
- Fixes #1632
- Fixes #1633
- Confirms #1624 is already fixed and covered by compose validation

## Validation
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test ./scripts/test/docker-compose-prod-secrets.test.ts ./scripts/test/validate-k8s-image-tags.test.ts ./scripts/test/k8s-runtime-hardening.test.ts