### PR TITLE
fix: harden trusted IP and admin token checks

### DIFF
--- a/apps/server/src/adapters/wechat-pay.ts
+++ b/apps/server/src/adapters/wechat-pay.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "@server/domain/ops/analytics";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { recordPaymentGrantRetry } from "@server/domain/ops/observability";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import {
   CallbackDeadLetterQueue,
   buildPaymentGrantRuntimePayload as buildSharedPaymentGrantRuntimePayload,
@@ -435,7 +436,7 @@ function readAdminToken(): string | null {
 
 function isAdminRequest(request: IncomingMessage): boolean {
   const adminToken = readAdminToken();
-  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
+  return timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken);
 }
 
 function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {

--- a/apps/server/src/domain/account/auth.ts
+++ b/apps/server/src/domain/account/auth.ts
@@ -38,6 +38,7 @@ import {
   type PlayerAccountSnapshot,
   type RoomSnapshotStore
 } from "@server/persistence";
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
 import { isPlayerBanActive } from "@server/domain/player-ban";
 import { assertDisplayNameAvailableOrThrow } from "@server/domain/account/display-name-rules";
 import { resolveFeatureEntitlementsForPlayer } from "@server/domain/battle/feature-flags";
@@ -1889,15 +1890,8 @@ function sendAuthFailure(
   });
 }
 
-function readHeaderCsvValue(value: string | string[] | undefined): string | null {
-  const headerValue = readHeaderValue(value);
-  return headerValue?.split(",")[0]?.trim() || null;
-}
-
 function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
-  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
-  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
-  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+  return resolveTrustedRequestIp(request);
 }
 
 function consumeSlidingWindowRateLimit(key: string, config = readAuthRuntimeConfig()): RateLimitResult {

--- a/apps/server/src/domain/account/player-accounts.ts
+++ b/apps/server/src/domain/account/player-accounts.ts
@@ -11,6 +11,7 @@ import {
 import { issueDailyLoginReward } from "@server/domain/economy/daily-login-rewards";
 import { resolveBattlePassConfig } from "@server/domain/economy/battle-pass";
 import { emitAnalyticsEvent } from "@server/domain/ops/analytics";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import {
   cachePlayerAccountAuthState,
   hashAccountPassword,
@@ -153,7 +154,7 @@ function emitExperimentExposureForSurface(
 
 function isAdminAuthorized(request: IncomingMessage): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
-  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
+  return timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken);
 }
 
 function validateWechatSignatureEnvelope(

--- a/apps/server/src/domain/battle/event-engine.ts
+++ b/apps/server/src/domain/battle/event-engine.ts
@@ -7,6 +7,7 @@ import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import type { DailyQuestConfigDefinition } from "@server/domain/economy/daily-quest-config";
 import type { PlayerAccountSnapshot, PlayerQuestRotationHistoryEntry, PlayerQuestState, RoomSnapshotStore } from "@server/persistence";
 import { normalizePlayerMailboxMessage } from "@server/domain/account/player-mailbox";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 
 interface SeasonalEventSummaryDocument {
@@ -150,7 +151,7 @@ function readAdminTokenFromRequest(request: Pick<IncomingMessage, "headers">): s
 
 function isAdminAuthorized(request: Pick<IncomingMessage, "headers">): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
-  return Boolean(adminToken) && readAdminTokenFromRequest(request) === adminToken;
+  return timingSafeCompareAdminToken(readAdminTokenFromRequest(request), adminToken);
 }
 
 function sendAdminUnauthorized(response: ServerResponse): void {

--- a/apps/server/src/domain/ops/client-error.ts
+++ b/apps/server/src/domain/ops/client-error.ts
@@ -4,6 +4,7 @@ import type { GuestAuthSession } from "@server/domain/account/auth";
 import { readGuestAuthTokenFromRequest, validateGuestAuthToken } from "@server/domain/account/auth";
 import { captureClientError } from "@server/domain/ops/error-monitoring";
 import { getRequestCorrelationId } from "@server/infra/http-request-context";
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
 import { recordHttpRateLimited, recordRuntimeErrorEvent } from "@server/domain/ops/observability";
 import type { RoomSnapshotStore } from "@server/persistence";
 
@@ -109,15 +110,8 @@ function readHeaderValue(value: string | string[] | undefined): string | null {
   return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
 }
 
-function readHeaderCsvValue(value: string | string[] | undefined): string | null {
-  const headerValue = readHeaderValue(value);
-  return headerValue?.split(",")[0]?.trim() || null;
-}
-
 function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
-  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
-  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
-  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+  return resolveTrustedRequestIp(request);
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {

--- a/apps/server/src/domain/social/guilds.ts
+++ b/apps/server/src/domain/social/guilds.ts
@@ -7,6 +7,7 @@ import { createGuild, createGuildRosterView, createGuildSummaryView, type GuildC
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { loadDisplayNameValidationRules } from "@server/domain/account/display-name-rules";
 import { recordHttpRateLimited } from "@server/domain/ops/observability";
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
 import type { GuildAuditLogRecord, GuildChatMessageRecord, RoomSnapshotStore } from "@server/persistence";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -88,11 +89,7 @@ function toGuildChatMessage(record: GuildChatMessageRecord): GuildChatMessage {
 }
 
 function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
-  const forwardedFor = request.headers["x-forwarded-for"];
-  const headerValue = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
-  const normalizedHeader = headerValue?.split(",")[0]?.trim();
-  const rawIp = normalizedHeader || request.socket.remoteAddress?.trim() || "unknown";
-  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+  return resolveTrustedRequestIp(request);
 }
 
 class GuildChatRateLimiter {

--- a/apps/server/src/domain/social/leaderboard.ts
+++ b/apps/server/src/domain/social/leaderboard.ts
@@ -10,6 +10,7 @@ import {
 } from "@server/domain/social/leaderboard-tier-thresholds";
 import type { RoomSnapshotStore } from "@server/persistence";
 import { isLeaderboardFrozen, isLeaderboardHidden } from "@server/domain/social/leaderboard-anti-abuse";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -34,7 +35,7 @@ function readHeaderValue(value: string | string[] | undefined): string | null {
 
 function isAdminAuthorized(request: IncomingMessage): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
-  return Boolean(adminToken) && readHeaderValue(request.headers["x-veil-admin-token"]) === adminToken;
+  return timingSafeCompareAdminToken(readHeaderValue(request.headers["x-veil-admin-token"]), adminToken);
 }
 
 function readLimit(request: IncomingMessage, fallback = 100): number {

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -8,6 +8,7 @@ import { sendMobilePushNotification } from "@server/adapters/mobile-push";
 import { recordMatchmakingRateLimited, setMatchmakingQueueDepth } from "@server/domain/ops/observability";
 import type { RoomSnapshotStore } from "@server/persistence";
 import { createRedisClient, readRedisUrl, type RedisClientLike } from "@server/infra/redis";
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
 import { sendWechatSubscribeMessage } from "@server/adapters/wechat-subscribe";
 
 export const DEFAULT_MATCHMAKING_QUEUE_TTL_SECONDS = 5 * 60;
@@ -104,15 +105,8 @@ function readHeaderValue(value: string | string[] | undefined): string | null {
   return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
 }
 
-function readHeaderCsvValue(value: string | string[] | undefined): string | null {
-  const headerValue = readHeaderValue(value);
-  return headerValue?.split(",")[0]?.trim() || null;
-}
-
 function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
-  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
-  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
-  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+  return resolveTrustedRequestIp(request);
 }
 
 function consumeSlidingWindowRateLimit(key: string, config = readMatchmakingRuntimeConfig()): RateLimitResult {

--- a/apps/server/src/domain/social/seasons.ts
+++ b/apps/server/src/domain/social/seasons.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RoomSnapshotStore } from "@server/persistence";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -17,11 +18,7 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
 
 function isAdminAuthorized(request: IncomingMessage): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
-  if (!adminToken) {
-    return false;
-  }
-  const headerToken = request.headers["x-veil-admin-token"];
-  return headerToken === adminToken;
+  return timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken);
 }
 
 const MAX_JSON_BODY_BYTES = 32 * 1024;

--- a/apps/server/src/infra/admin-token.ts
+++ b/apps/server/src/infra/admin-token.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from "node:crypto";
+
+function readHeaderToken(value: string | string[] | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+  return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
+}
+
+export function timingSafeCompareAdminToken(
+  actual: string | string[] | null | undefined,
+  expected: string | null | undefined
+): boolean {
+  if (!expected) {
+    return false;
+  }
+  const actualToken = readHeaderToken(actual);
+  if (!actualToken) {
+    return false;
+  }
+  const actualBuffer = Buffer.from(actualToken);
+  const expectedBuffer = Buffer.from(expected);
+  if (actualBuffer.length !== expectedBuffer.length) {
+    timingSafeEqual(Buffer.alloc(expectedBuffer.length), expectedBuffer);
+    return false;
+  }
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/apps/server/src/infra/http-rate-limit.ts
+++ b/apps/server/src/infra/http-rate-limit.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { recordHttpRateLimited } from "@server/domain/ops/observability";
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
 
 const DEFAULT_HTTP_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_HTTP_RATE_LIMIT_GLOBAL_MAX = 200;
@@ -70,19 +71,8 @@ function readHttpRateLimitConfig(env: NodeJS.ProcessEnv = process.env): HttpRate
   };
 }
 
-function readHeaderValue(value: string | string[] | undefined): string | null {
-  return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
-}
-
-function readHeaderCsvValue(value: string | string[] | undefined): string | null {
-  const headerValue = readHeaderValue(value);
-  return headerValue?.split(",")[0]?.trim() || null;
-}
-
 function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
-  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
-  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
-  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+  return resolveTrustedRequestIp(request);
 }
 
 function resolveHttpRateLimitPolicy(pathname: string, config = readHttpRateLimitConfig()): HttpRateLimitPolicy {

--- a/apps/server/src/infra/request-ip.ts
+++ b/apps/server/src/infra/request-ip.ts
@@ -1,0 +1,151 @@
+import type { IncomingMessage } from "node:http";
+import { isIP } from "node:net";
+
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
+}
+
+function readHeaderCsvValue(value: string | string[] | undefined): string | null {
+  const headerValue = readHeaderValue(value);
+  return headerValue?.split(",")[0]?.trim() || null;
+}
+
+function normalizeIpAddress(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return null;
+  }
+  return normalized.startsWith("::ffff:") ? normalized.slice("::ffff:".length) : normalized;
+}
+
+function parseIpv4ToBigInt(value: string): bigint | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  let result = 0n;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+    const octet = Number(part);
+    if (octet < 0 || octet > 255) {
+      return null;
+    }
+    result = (result << 8n) + BigInt(octet);
+  }
+  return result;
+}
+
+function parseExpandedIpv6Parts(parts: string[]): bigint | null {
+  if (parts.length !== 8) {
+    return null;
+  }
+  let result = 0n;
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/i.test(part)) {
+      return null;
+    }
+    result = (result << 16n) + BigInt(parseInt(part, 16));
+  }
+  return result;
+}
+
+function parseIpv6ToBigInt(value: string): bigint | null {
+  const normalized = value.toLowerCase();
+  if (!/^[0-9a-f:]+$/.test(normalized)) {
+    return null;
+  }
+  const hasCompression = normalized.includes("::");
+  const [head, tail = ""] = normalized.split("::");
+  const headParts = head ? head.split(":").filter(Boolean) : [];
+  const tailParts = tail ? tail.split(":").filter(Boolean) : [];
+  if (hasCompression) {
+    const missingCount = 8 - (headParts.length + tailParts.length);
+    if (missingCount < 0) {
+      return null;
+    }
+    return parseExpandedIpv6Parts([
+      ...headParts,
+      ...Array.from({ length: missingCount }, () => "0"),
+      ...tailParts
+    ]);
+  }
+  return parseExpandedIpv6Parts(normalized.split(":"));
+}
+
+function parseIpToBigInt(value: string): { version: 4 | 6; value: bigint } | null {
+  const normalized = normalizeIpAddress(value);
+  if (!normalized) {
+    return null;
+  }
+  const version = isIP(normalized);
+  if (version === 4) {
+    const parsed = parseIpv4ToBigInt(normalized);
+    return parsed == null ? null : { version: 4, value: parsed };
+  }
+  if (version === 6) {
+    const parsed = parseIpv6ToBigInt(normalized);
+    return parsed == null ? null : { version: 6, value: parsed };
+  }
+  return null;
+}
+
+function isIpInCidr(address: string, cidr: string): boolean {
+  const [range, prefixText] = cidr.split("/");
+  if (!range || prefixText == null) {
+    return false;
+  }
+  const parsedAddress = parseIpToBigInt(address);
+  const parsedRange = parseIpToBigInt(range);
+  if (!parsedAddress || !parsedRange || parsedAddress.version !== parsedRange.version) {
+    return false;
+  }
+  const maxBits = parsedAddress.version === 4 ? 32 : 128;
+  const prefix = Number(prefixText);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > maxBits) {
+    return false;
+  }
+  if (prefix === 0) {
+    return true;
+  }
+  const shift = BigInt(maxBits - prefix);
+  return (parsedAddress.value >> shift) === (parsedRange.value >> shift);
+}
+
+function parseTrustedProxyRules(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.VEIL_TRUSTED_PROXIES ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function isTrustedProxy(address: string | null, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!address) {
+    return false;
+  }
+  const normalizedAddress = normalizeIpAddress(address);
+  if (!normalizedAddress) {
+    return false;
+  }
+  return parseTrustedProxyRules(env).some((rule) => {
+    if (rule.includes("/")) {
+      return isIpInCidr(normalizedAddress, rule);
+    }
+    return normalizeIpAddress(rule) === normalizedAddress;
+  });
+}
+
+export function resolveTrustedRequestIp(
+  request: Pick<IncomingMessage, "headers" | "socket">,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const socketIp = normalizeIpAddress(request.socket.remoteAddress?.trim()) ?? "unknown";
+  if (!isTrustedProxy(socketIp, env)) {
+    return socketIp;
+  }
+  const forwardedIp =
+    normalizeIpAddress(readHeaderValue(request.headers["x-real-ip"])) ??
+    normalizeIpAddress(readHeaderCsvValue(request.headers["x-forwarded-for"]));
+  return forwardedIp ?? socketIp;
+}

--- a/apps/server/src/transport/http/minor-protection-routes.ts
+++ b/apps/server/src/transport/http/minor-protection-routes.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { buildMinorProtectionBlockDetails, getMinorProtectionDateKey, readMinorProtectionConfig } from "@server/domain/ops/minor-protection";
 import type { PlayerAccountSnapshot, RoomSnapshotStore } from "@server/persistence";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 
 interface MinorProtectionApp {
@@ -16,7 +17,7 @@ function sendJson(response: ServerResponse, statusCode: number, payload: unknown
 
 function isAdminAuthorized(request: IncomingMessage): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
-  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
+  return timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken);
 }
 
 function readOptionalTrimmedQueryParam(request: IncomingMessage, key: string): string | undefined {

--- a/apps/server/test/admin-token.test.ts
+++ b/apps/server/test/admin-token.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
+
+test("timingSafeCompareAdminToken rejects missing and mismatched tokens", () => {
+  assert.equal(timingSafeCompareAdminToken(undefined, "admin-token"), false);
+  assert.equal(timingSafeCompareAdminToken("wrong-token", "admin-token"), false);
+  assert.equal(timingSafeCompareAdminToken("short", "admin-token"), false);
+});
+
+test("timingSafeCompareAdminToken accepts the matching token", () => {
+  assert.equal(timingSafeCompareAdminToken("admin-token", "admin-token"), true);
+});

--- a/apps/server/test/http-rate-limit.test.ts
+++ b/apps/server/test/http-rate-limit.test.ts
@@ -33,6 +33,7 @@ test("HTTP rate limiting returns 429 with Retry-After and increments Prometheus 
   withEnvOverrides(
     {
       ADMIN_SECRET: "test-admin-secret",
+      VEIL_TRUSTED_PROXIES: "127.0.0.1",
       VEIL_RATE_LIMIT_HTTP_WINDOW_MS: "60000",
       VEIL_RATE_LIMIT_HTTP_GLOBAL_MAX: "2",
       VEIL_RATE_LIMIT_HTTP_SHOP_MAX: "1",
@@ -111,4 +112,37 @@ test("HTTP rate limiting returns 429 with Retry-After and increments Prometheus 
 
   assert.equal(metricsResponse.status, 200);
   assert.match(metricsText, /^veil_http_rate_limited_total 4$/m);
+});
+
+test("HTTP rate limiting ignores spoofed forwarded headers from untrusted sockets", { concurrency: false }, async (t) => {
+  resetRuntimeObservability();
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      ADMIN_SECRET: "test-admin-secret",
+      VEIL_RATE_LIMIT_HTTP_WINDOW_MS: "60000",
+      VEIL_RATE_LIMIT_HTTP_GLOBAL_MAX: "1"
+    },
+    cleanup
+  );
+
+  const port = 47000 + Math.floor(Math.random() * 1000);
+  const runtime = await startDevServer(port, "127.0.0.1");
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetRuntimeObservability();
+    await runtime.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/lobby/rooms`, {
+    headers: withHeaders("198.51.100.20")
+  });
+  assert.equal(firstResponse.status, 200);
+
+  const spoofedFollowup = await fetch(`http://127.0.0.1:${port}/api/lobby/rooms`, {
+    headers: withHeaders("203.0.113.200")
+  });
+  assert.equal(spoofedFollowup.status, 429);
+  assert.equal(spoofedFollowup.headers.get("Retry-After"), "60");
 });

--- a/apps/server/test/request-ip.test.ts
+++ b/apps/server/test/request-ip.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveTrustedRequestIp } from "@server/infra/request-ip";
+
+test("resolveTrustedRequestIp ignores forwarded headers from untrusted sockets", () => {
+  assert.equal(
+    resolveTrustedRequestIp(
+      {
+        headers: {
+          "x-forwarded-for": "198.51.100.20",
+          "x-real-ip": "198.51.100.21"
+        },
+        socket: {
+          remoteAddress: "127.0.0.1"
+        }
+      },
+      {}
+    ),
+    "127.0.0.1"
+  );
+});
+
+test("resolveTrustedRequestIp honors x-real-ip when the socket is a trusted proxy", () => {
+  assert.equal(
+    resolveTrustedRequestIp(
+      {
+        headers: {
+          "x-forwarded-for": "198.51.100.20",
+          "x-real-ip": "198.51.100.21"
+        },
+        socket: {
+          remoteAddress: "10.0.0.9"
+        }
+      },
+      {
+        VEIL_TRUSTED_PROXIES: "10.0.0.0/8"
+      }
+    ),
+    "198.51.100.21"
+  );
+});


### PR DESCRIPTION
## Summary
- centralize trusted proxy IP resolution and stop trusting spoofed forwarded headers from untrusted sockets
- replace string equality admin-token checks with timing-safe comparison helpers
- cover the new helpers and affected routes with focused server tests

## Issues
- Fixes #1629
- Fixes #1630

## Validation
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test ./apps/server/test/request-ip.test.ts ./apps/server/test/admin-token.test.ts ./apps/server/test/http-rate-limit.test.ts ./apps/server/test/minor-protection-routes.test.ts ./apps/server/test/leaderboard-routes.test.ts ./apps/server/test/season-routes.test.ts ./apps/server/test/event-admin-routes.test.ts ./apps/server/test/wechat-pay-routes.test.ts
- npm run typecheck -- server