### PR TITLE
fix: add H5 runtime error boundary

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -72,6 +72,7 @@ import {
   resolveRoomFeedbackTone
 } from "./room-feedback";
 import { createMainSessionRuntime } from "./main-session-runtime";
+import { bindClientRuntimeErrorBoundary } from "./runtime-error-reporting";
 import {
   clampWorldCoordinate,
   diagnosticsConnectionStatusLabel,
@@ -466,6 +467,23 @@ let achievementToastTaskId: number | null = null;
 const seenAchievementToastEventIds = new Set<string>();
 const pendingAchievementToasts: Array<{ eventId: string; title: string; detail: string }> = [];
 let hasHydratedAchievementFeed = false;
+
+bindClientRuntimeErrorBoundary({
+  apiBaseUrl: runtimeServerHttpUrl,
+  readAuthToken: () => readStoredAuthSession()?.token ?? null,
+  readContext: () => ({
+    runtimeTarget: runtimeServerHttpUrl,
+    route: window.location.href,
+    userAgent: globalThis.navigator?.userAgent ?? "unknown",
+    roomId: state.world.meta.roomId,
+    playerId,
+    diagnostics: {
+      lastUpdateAt: state.diagnostics.lastUpdateAt,
+      lastUpdateSource: state.diagnostics.lastUpdateSource,
+      lastUpdateReason: state.diagnostics.lastUpdateReason
+    }
+  })
+});
 
 interface PendingPrediction {
   world: PlayerWorldView;

--- a/apps/client/src/runtime-error-reporting.ts
+++ b/apps/client/src/runtime-error-reporting.ts
@@ -1,0 +1,132 @@
+import { buildAuthHeaders } from "./auth-session";
+
+const DEFAULT_CLIENT_RUNTIME_PLATFORM = "h5-shell";
+const DEFAULT_CLIENT_RUNTIME_VERSION = "development";
+
+interface GlobalErrorBoundaryEventLike {
+  message?: string;
+  error?: unknown;
+  reason?: unknown;
+}
+
+interface EventTargetLike {
+  addEventListener(type: string, listener: (event: GlobalErrorBoundaryEventLike) => void): void;
+  removeEventListener(type: string, listener: (event: GlobalErrorBoundaryEventLike) => void): void;
+}
+
+interface RuntimeErrorReportingDependencies {
+  eventTarget?: EventTargetLike | null;
+  fetchImpl?: typeof fetch;
+}
+
+interface ReportClientRuntimeErrorInput {
+  apiBaseUrl: string;
+  authToken?: string | null;
+  payload: {
+    platform: string;
+    version: string;
+    errorMessage: string;
+    stack?: string;
+    context?: Record<string, unknown>;
+  };
+  fetchImpl?: typeof fetch;
+}
+
+interface BindClientRuntimeErrorBoundaryInput extends RuntimeErrorReportingDependencies {
+  apiBaseUrl: string;
+  readAuthToken: () => string | null;
+  readContext: () => Record<string, unknown>;
+  platform?: string;
+  version?: string;
+}
+
+function resolveClientRuntimeVersion(): string {
+  if (typeof import.meta !== "undefined" && typeof import.meta.env?.MODE === "string" && import.meta.env.MODE.trim()) {
+    return import.meta.env.MODE.trim();
+  }
+  return DEFAULT_CLIENT_RUNTIME_VERSION;
+}
+
+function normalizeRuntimeBoundaryFailure(event: GlobalErrorBoundaryEventLike): {
+  errorMessage: string;
+  stack?: string;
+} {
+  const reason = event.error ?? event.reason;
+  if (reason instanceof Error) {
+    return {
+      errorMessage: reason.message || event.message?.trim() || "unknown_client_error",
+      ...(reason.stack ? { stack: reason.stack } : {})
+    };
+  }
+  if (typeof event.message === "string" && event.message.trim()) {
+    return {
+      errorMessage: event.message.trim()
+    };
+  }
+  if (typeof reason === "string" && reason.trim()) {
+    return {
+      errorMessage: reason.trim()
+    };
+  }
+  return {
+    errorMessage: String(reason ?? "unknown_client_error")
+  };
+}
+
+export async function reportClientRuntimeError({
+  apiBaseUrl,
+  authToken,
+  payload,
+  fetchImpl = fetch
+}: ReportClientRuntimeErrorInput): Promise<void> {
+  await fetchImpl(`${apiBaseUrl}/api/errors`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...buildAuthHeaders(authToken)
+    },
+    body: JSON.stringify(payload)
+  });
+}
+
+export function bindClientRuntimeErrorBoundary({
+  apiBaseUrl,
+  readAuthToken,
+  readContext,
+  platform = DEFAULT_CLIENT_RUNTIME_PLATFORM,
+  version = resolveClientRuntimeVersion(),
+  eventTarget = globalThis as typeof globalThis & Partial<EventTargetLike>,
+  fetchImpl = fetch
+}: BindClientRuntimeErrorBoundaryInput): (() => void) | null {
+  if (
+    !eventTarget ||
+    typeof eventTarget.addEventListener !== "function" ||
+    typeof eventTarget.removeEventListener !== "function"
+  ) {
+    return null;
+  }
+
+  const handleRuntimeFailure = (event: GlobalErrorBoundaryEventLike): void => {
+    const normalized = normalizeRuntimeBoundaryFailure(event);
+    void reportClientRuntimeError({
+      apiBaseUrl,
+      authToken: readAuthToken(),
+      fetchImpl,
+      payload: {
+        platform,
+        version,
+        errorMessage: normalized.errorMessage,
+        ...(normalized.stack ? { stack: normalized.stack } : {}),
+        context: readContext()
+      }
+    }).catch(() => undefined);
+  };
+
+  eventTarget.addEventListener("error", handleRuntimeFailure);
+  eventTarget.addEventListener("unhandledrejection", handleRuntimeFailure);
+
+  return () => {
+    eventTarget.removeEventListener("error", handleRuntimeFailure);
+    eventTarget.removeEventListener("unhandledrejection", handleRuntimeFailure);
+  };
+}

--- a/apps/client/test/runtime-error-reporting.test.ts
+++ b/apps/client/test/runtime-error-reporting.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { bindClientRuntimeErrorBoundary, reportClientRuntimeError } from "../src/runtime-error-reporting";
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("reportClientRuntimeError posts the expected payload and auth header", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  await reportClientRuntimeError({
+    apiBaseUrl: "http://127.0.0.1:2567",
+    authToken: "token-123",
+    fetchImpl: (async (url, init) => {
+      calls.push({ url: String(url), init });
+      return new Response(null, { status: 202 });
+    }) as typeof fetch,
+    payload: {
+      platform: "h5-shell",
+      version: "test",
+      errorMessage: "boom",
+      context: {
+        route: "http://127.0.0.1:4173/"
+      }
+    }
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.url, "http://127.0.0.1:2567/api/errors");
+  assert.equal((calls[0]?.init?.headers as Record<string, string>).Authorization, "Bearer token-123");
+  assert.equal((calls[0]?.init?.headers as Record<string, string>)["Content-Type"], "application/json");
+  assert.deepEqual(JSON.parse(String(calls[0]?.init?.body)), {
+    platform: "h5-shell",
+    version: "test",
+    errorMessage: "boom",
+    context: {
+      route: "http://127.0.0.1:4173/"
+    }
+  });
+});
+
+test("bindClientRuntimeErrorBoundary reports uncaught errors and rejections", async () => {
+  const listeners = new Map<string, (event: unknown) => void>();
+  const payloads: Array<Record<string, unknown>> = [];
+  const unbind = bindClientRuntimeErrorBoundary({
+    apiBaseUrl: "http://127.0.0.1:2567",
+    version: "test",
+    eventTarget: {
+      addEventListener(type, listener) {
+        listeners.set(type, listener);
+      },
+      removeEventListener(type) {
+        listeners.delete(type);
+      }
+    },
+    fetchImpl: (async (_url, init) => {
+      payloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 202 });
+    }) as typeof fetch,
+    readAuthToken: () => "session-token",
+    readContext: () => ({
+      roomId: "room-alpha",
+      playerId: "player-alpha"
+    })
+  });
+
+  assert.ok(unbind);
+  listeners.get("error")?.({
+    error: new Error("uncaught-boom")
+  });
+  listeners.get("unhandledrejection")?.({
+    reason: "async-boom"
+  });
+  await flushMicrotasks();
+
+  assert.equal(payloads.length, 2);
+  assert.equal(payloads[0]?.errorMessage, "uncaught-boom");
+  assert.equal(payloads[1]?.errorMessage, "async-boom");
+  assert.deepEqual(payloads[0]?.context, {
+    roomId: "room-alpha",
+    playerId: "player-alpha"
+  });
+
+  unbind?.();
+  assert.equal(listeners.size, 0);
+});


### PR DESCRIPTION
## Summary
- add a global H5 runtime error boundary that posts to /api/errors
- preserve auth headers and runtime context in client-side crash reports
- verify the boot-room smoke runtime-target handling that already covers #1620 and #1621

## Issues
- Fixes #1625
- Confirms #1620 is already fixed on current main
- Confirms #1621 is already fixed on current main

## Validation
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test ./apps/client/test/runtime-error-reporting.test.ts ./scripts/test/client-boot-room-smoke.test.ts ./apps/server/test/client-error-routes.test.ts
- npm run typecheck -- client:h5