### PR TITLE
fix: require explicit auth secret in production

### DIFF
--- a/apps/server/src/domain/account/auth.ts
+++ b/apps/server/src/domain/account/auth.ts
@@ -182,9 +182,19 @@ const guestSessionsById = new Map<string, GuestAuthSession>();
 const accountAuthStateByPlayerId = new Map<string, AccountAuthSessionState>();
 const accountRegistrationStateByLoginId = new Map<string, AccountRegistrationState>();
 const passwordRecoveryStateByLoginId = new Map<string, PasswordRecoveryState>();
+let nonProductionAuthSecret: string | null = null;
 
 function readAuthSecret(env: NodeJS.ProcessEnv = process.env): string {
-  return readRuntimeSecret("VEIL_AUTH_SECRET", env) || "project-veil-dev-secret";
+  const configuredSecret = readRuntimeSecret("VEIL_AUTH_SECRET", env);
+  if (configuredSecret) {
+    return configuredSecret;
+  }
+  if (env.NODE_ENV?.trim().toLowerCase() === "production") {
+    throw new Error("VEIL_AUTH_SECRET must be configured for production auth signing");
+  }
+
+  nonProductionAuthSecret ??= randomBytes(32).toString("hex");
+  return nonProductionAuthSecret;
 }
 
 function countActiveAccountLockouts(): number {

--- a/apps/server/src/domain/ops/runtime-secrets.ts
+++ b/apps/server/src/domain/ops/runtime-secrets.ts
@@ -32,6 +32,10 @@ function normalizeSecretValue(value: string): string {
   return value.trim();
 }
 
+function isProductionEnvironment(env: NodeJS.ProcessEnv): boolean {
+  return env.NODE_ENV?.trim().toLowerCase() === "production";
+}
+
 function readRequiredEnvValue(env: NodeJS.ProcessEnv, key: string): string {
   const value = env[key]?.trim();
   if (!value) {
@@ -169,6 +173,17 @@ function validateAwsManagedSecrets(env: NodeJS.ProcessEnv): void {
   }
 }
 
+function validateProductionRuntimeSecrets(env: NodeJS.ProcessEnv): void {
+  if (!isProductionEnvironment(env)) {
+    return;
+  }
+  if (readRuntimeSecret("VEIL_AUTH_SECRET", env)) {
+    return;
+  }
+
+  throw new Error("VEIL_AUTH_SECRET must be configured for production startup");
+}
+
 export function readRuntimeSecret(key: RuntimeSecretKey, env: NodeJS.ProcessEnv = process.env): string | undefined {
   const runtimeValue = runtimeSecrets.get(key)?.trim();
   if (runtimeValue) {
@@ -191,6 +206,7 @@ export async function loadRuntimeSecrets(
   runtimeSecrets = new Map();
 
   if (provider === "env") {
+    validateProductionRuntimeSecrets(env);
     return;
   }
 
@@ -199,6 +215,7 @@ export async function loadRuntimeSecrets(
   const payload = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
   runtimeSecrets = parseAwsSecretPayload(readAwsSecretText(payload));
   validateAwsManagedSecrets(env);
+  validateProductionRuntimeSecrets(env);
 }
 
 export function setRuntimeSecretsForTest(values: Partial<Record<RuntimeSecretKey, string>>): void {

--- a/apps/server/test/auth-secret.test.ts
+++ b/apps/server/test/auth-secret.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { issueGuestAuthSession, resetGuestAuthSessions } from "@server/domain/account/auth";
+import { resetRuntimeSecretsForTest } from "@server/domain/ops/runtime-secrets";
+
+test("issueGuestAuthSession rejects production signing when VEIL_AUTH_SECRET is missing", { concurrency: false }, () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousAuthSecret = process.env.VEIL_AUTH_SECRET;
+
+  resetGuestAuthSessions();
+  resetRuntimeSecretsForTest();
+  delete process.env.VEIL_AUTH_SECRET;
+  process.env.NODE_ENV = "production";
+
+  try {
+    assert.throws(
+      () =>
+        issueGuestAuthSession({
+          playerId: "player-production-secret",
+          displayName: "Production Secret"
+        }),
+      /VEIL_AUTH_SECRET/
+    );
+  } finally {
+    resetGuestAuthSessions();
+    resetRuntimeSecretsForTest();
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    if (previousAuthSecret === undefined) {
+      delete process.env.VEIL_AUTH_SECRET;
+    } else {
+      process.env.VEIL_AUTH_SECRET = previousAuthSecret;
+    }
+  }
+});

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -990,6 +990,8 @@ test("stale leave after a successful reconnect does not clear the resumed player
 test("reconnect with an expired tracked auth token sends SESSION_EXPIRED and rejects the resumed client", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
+  const previousAuthSecret = process.env.VEIL_AUTH_SECRET;
+  process.env.VEIL_AUTH_SECRET = "test-room-auth-secret";
   const room = await createTestRoom(`lifecycle-reconnect-expired-token-${Date.now()}`);
   const originalClient = createFakeClient("session-expired-token-original");
   const reconnectedClient = createFakeClient("session-expired-token-resumed");
@@ -1010,6 +1012,11 @@ test("reconnect with an expired tracked auth token sends SESSION_EXPIRED and rej
     cleanupRoom(room);
     resetLobbyRoomRegistry();
     configureRoomSnapshotStore(null);
+    if (previousAuthSecret === undefined) {
+      delete process.env.VEIL_AUTH_SECRET;
+    } else {
+      process.env.VEIL_AUTH_SECRET = previousAuthSecret;
+    }
   });
 
   await connectPlayer(room, originalClient, "player-1", "connect-expired-token", expiringSession.token);
@@ -1031,6 +1038,8 @@ test("reconnect with an expired tracked auth token sends SESSION_EXPIRED and rej
 test("TOKEN_REFRESH updates the tracked auth session so reconnect accepts the refreshed token", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
+  const previousAuthSecret = process.env.VEIL_AUTH_SECRET;
+  process.env.VEIL_AUTH_SECRET = "test-room-auth-secret";
   const room = await createTestRoom(`lifecycle-reconnect-token-refresh-${Date.now()}`);
   const originalClient = createFakeClient("session-token-refresh-original");
   const reconnectedClient = createFakeClient("session-token-refresh-resumed");
@@ -1059,6 +1068,11 @@ test("TOKEN_REFRESH updates the tracked auth session so reconnect accepts the re
     cleanupRoom(room);
     resetLobbyRoomRegistry();
     configureRoomSnapshotStore(null);
+    if (previousAuthSecret === undefined) {
+      delete process.env.VEIL_AUTH_SECRET;
+    } else {
+      process.env.VEIL_AUTH_SECRET = previousAuthSecret;
+    }
   });
 
   await connectPlayer(room, originalClient, "player-1", "connect-token-refresh", expiringSession.token);

--- a/apps/server/test/runtime-secrets.test.ts
+++ b/apps/server/test/runtime-secrets.test.ts
@@ -91,3 +91,36 @@ test("loadRuntimeSecrets fails when the AWS secret bundle is missing required ke
 
   resetRuntimeSecretsForTest();
 });
+
+test("loadRuntimeSecrets rejects production env startup when VEIL_AUTH_SECRET is missing", { concurrency: false }, async () => {
+  resetRuntimeSecretsForTest();
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousAuthSecret = process.env.VEIL_AUTH_SECRET;
+
+  delete process.env.VEIL_AUTH_SECRET;
+  process.env.NODE_ENV = "production";
+
+  try {
+    await assert.rejects(
+      loadRuntimeSecrets({
+        ...process.env,
+        NODE_ENV: "production",
+        VEIL_SECRET_PROVIDER: "env",
+        VEIL_AUTH_SECRET: undefined
+      }),
+      /VEIL_AUTH_SECRET/
+    );
+  } finally {
+    resetRuntimeSecretsForTest();
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    if (previousAuthSecret === undefined) {
+      delete process.env.VEIL_AUTH_SECRET;
+    } else {
+      process.env.VEIL_AUTH_SECRET = previousAuthSecret;
+    }
+  }
+});


### PR DESCRIPTION
Fixes #1641

- remove the hard-coded auth secret fallback
- fail production startup when VEIL_AUTH_SECRET is missing
- add focused auth secret regression coverage