### PR TITLE
fix: secure redis and mysql transport defaults

### DIFF
--- a/apps/server/src/infra/mysql-pool.ts
+++ b/apps/server/src/infra/mysql-pool.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { createPool, type Pool, type PoolOptions } from "mysql2/promise";
 
 export const DEFAULT_MYSQL_POOL_CONNECTION_LIMIT = 4;
@@ -5,6 +6,9 @@ export const DEFAULT_MYSQL_POOL_MAX_IDLE = 4;
 export const DEFAULT_MYSQL_POOL_IDLE_TIMEOUT_MS = 60_000;
 export const DEFAULT_MYSQL_POOL_QUEUE_LIMIT = 128;
 export const DEFAULT_MYSQL_POOL_WAIT_FOR_CONNECTIONS = true;
+export const DEFAULT_MYSQL_SSL_MODE = "disabled";
+
+export type MySqlSslMode = "disabled" | "required" | "verify-ca";
 
 export interface MySqlPoolConfig {
   connectionLimit: number;
@@ -14,12 +18,18 @@ export interface MySqlPoolConfig {
   waitForConnections: boolean;
 }
 
+export interface MySqlPoolSslConfig {
+  mode: MySqlSslMode;
+  caPath: string | null;
+}
+
 export interface MySqlPoolConnectionConfig {
   host: string;
   port: number;
   user: string;
   password: string;
   database: string;
+  ssl?: MySqlPoolSslConfig;
   pool: MySqlPoolConfig;
 }
 
@@ -136,6 +146,24 @@ export function createTrackedMySqlPool(
 }
 
 export function buildMySqlPoolOptions(config: MySqlPoolConnectionConfig): PoolOptions {
+  const sslMode = config.ssl?.mode ?? DEFAULT_MYSQL_SSL_MODE;
+  let ssl: Exclude<NonNullable<PoolOptions["ssl"]>, string> | undefined;
+
+  if (sslMode === "required") {
+    ssl = {
+      rejectUnauthorized: false
+    };
+  } else if (sslMode === "verify-ca") {
+    ssl = {
+      rejectUnauthorized: true,
+      verifyIdentity: true
+    };
+    const caPath = config.ssl?.caPath?.trim();
+    if (caPath) {
+      ssl.ca = readFileSync(caPath, "utf8");
+    }
+  }
+
   return {
     host: config.host,
     port: config.port,
@@ -147,6 +175,7 @@ export function buildMySqlPoolOptions(config: MySqlPoolConnectionConfig): PoolOp
     idleTimeout: config.pool.idleTimeoutMs,
     queueLimit: config.pool.queueLimit,
     waitForConnections: config.pool.waitForConnections,
+    ...(ssl ? { ssl } : {}),
     namedPlaceholders: true
   };
 }

--- a/apps/server/src/infra/redis.ts
+++ b/apps/server/src/infra/redis.ts
@@ -71,10 +71,22 @@ export function createRedisDriver(redisUrl: string): RedisDriver {
   return new RedisDriver(redisUrl);
 }
 
+function redactRedisUrl(redisUrl: string): string {
+  try {
+    const url = new URL(redisUrl);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return "[invalid-redis-url]";
+  }
+}
+
 export function createRedisClient(redisUrl: string, deps: CreateRedisClientDependencies = {}): RedisClientLike {
   const RedisCtor = deps.RedisCtor ?? (Redis as unknown as RedisConstructorLike);
   const logger = deps.logger ?? console;
   const captureRuntimeError = deps.recordRuntimeErrorEvent ?? recordRuntimeErrorEvent;
+  const redactedRedisUrl = redactRedisUrl(redisUrl);
   const client = new RedisCtor(redisUrl, {
     maxRetriesPerRequest: 3,
     enableReadyCheck: true,
@@ -103,7 +115,7 @@ export function createRedisClient(redisUrl: string, deps: CreateRedisClientDepen
         action: "redis.connect",
         statusCode: null,
         crash: false,
-        detail: redisUrl
+        detail: redactedRedisUrl
       }
     });
   });

--- a/apps/server/src/persistence/mysql/store.ts
+++ b/apps/server/src/persistence/mysql/store.ts
@@ -20,7 +20,10 @@ import {
   DEFAULT_MYSQL_POOL_MAX_IDLE,
   DEFAULT_MYSQL_POOL_QUEUE_LIMIT,
   DEFAULT_MYSQL_POOL_WAIT_FOR_CONNECTIONS,
-  type MySqlPoolConfig
+  DEFAULT_MYSQL_SSL_MODE,
+  type MySqlPoolConfig,
+  type MySqlPoolSslConfig,
+  type MySqlSslMode
 } from "@server/infra/mysql-pool";
 import type { RoomPersistenceSnapshot } from "@server/index";
 import {
@@ -240,6 +243,7 @@ export interface MySqlPersistenceConfig {
   user: string;
   password: string;
   database: string;
+  ssl?: MySqlPoolSslConfig;
   pool: MySqlPoolConfig;
   retention: SnapshotRetentionPolicy;
   playerNameHistoryRetention: PlayerNameHistoryRetentionPolicy;
@@ -2702,12 +2706,15 @@ export function readMySqlPersistenceConfig(env: NodeJS.ProcessEnv = process.env)
     return null;
   }
 
+  const ssl = readMySqlSslConfig(env);
+
   return {
     host,
     port: Number(env.VEIL_MYSQL_PORT ?? 3306),
     user,
     password,
     database: env.VEIL_MYSQL_DATABASE ?? MYSQL_DEFAULT_DATABASE,
+    ssl,
     pool: {
       connectionLimit: readPositiveInteger(env.VEIL_MYSQL_POOL_CONNECTION_LIMIT, DEFAULT_MYSQL_POOL_CONNECTION_LIMIT),
       maxIdle: readPositiveInteger(env.VEIL_MYSQL_POOL_MAX_IDLE, DEFAULT_MYSQL_POOL_MAX_IDLE),
@@ -2740,6 +2747,33 @@ export function readMySqlPersistenceConfig(env: NodeJS.ProcessEnv = process.env)
       )
     }
   };
+}
+
+function readMySqlSslConfig(env: NodeJS.ProcessEnv): MySqlPoolSslConfig {
+  const rawMode = env.VEIL_MYSQL_SSL_MODE?.trim().toLowerCase();
+  const mode = rawMode ? parseMySqlSslMode(rawMode) : DEFAULT_MYSQL_SSL_MODE;
+  const isProductionEnvironment = env.NODE_ENV?.trim().toLowerCase() === "production";
+  if (isProductionEnvironment && mode === "disabled") {
+    throw new Error("VEIL_MYSQL_SSL_MODE must be set to required or verify-ca when NODE_ENV=production");
+  }
+
+  return {
+    mode,
+    caPath: env.VEIL_MYSQL_SSL_CA_PATH?.trim() || null
+  };
+}
+
+function parseMySqlSslMode(value: string): MySqlSslMode {
+  switch (value) {
+    case "disabled":
+    case "required":
+    case "verify-ca":
+      return value;
+    default:
+      throw new Error(
+        `Unsupported VEIL_MYSQL_SSL_MODE "${value}". Expected one of disabled, required, verify-ca`
+      );
+  }
 }
 
 export function buildMySqlSchemaSql(database = MYSQL_DEFAULT_DATABASE): string {

--- a/apps/server/test/mysql-pool-observability.test.ts
+++ b/apps/server/test/mysql-pool-observability.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import test from "node:test";
 import type { Pool } from "mysql2/promise";
-import { createTrackedMySqlPool } from "@server/infra/mysql-pool";
+import { buildMySqlPoolOptions, createTrackedMySqlPool } from "@server/infra/mysql-pool";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 
 test("prometheus metrics expose mysql pool pressure gauges when mysql pools are configured", async (t) => {
@@ -92,4 +95,65 @@ test("prometheus db pool gauges track active and queued requests from pool callb
   metrics = buildPrometheusMetricsDocument();
   assert.match(metrics, /^veil_db_pool_queue_depth\{pool="config_center"\} 0$/m);
   assert.match(metrics, /^veil_mysql_pool_queue_depth\{pool="config_center"\} 0$/m);
+});
+
+test("buildMySqlPoolOptions enables encrypted MySQL transport in required mode", () => {
+  const options = buildMySqlPoolOptions({
+    host: "127.0.0.1",
+    port: 3306,
+    user: "veil",
+    password: "veil",
+    database: "project_veil",
+    ssl: {
+      mode: "required",
+      caPath: null
+    },
+    pool: {
+      connectionLimit: 4,
+      maxIdle: 4,
+      idleTimeoutMs: 60_000,
+      queueLimit: 0,
+      waitForConnections: true
+    }
+  });
+
+  assert.deepEqual(options.ssl, {
+    rejectUnauthorized: false
+  });
+});
+
+test("buildMySqlPoolOptions verifies the server certificate when verify-ca mode is configured", () => {
+  const tempDirectory = mkdtempSync(join(tmpdir(), "project-veil-mysql-ca-"));
+  const caPath = join(tempDirectory, "rds-ca.pem");
+  const caBundle = "-----BEGIN CERTIFICATE-----\nmock-ca\n-----END CERTIFICATE-----\n";
+  writeFileSync(caPath, caBundle, "utf8");
+
+  try {
+    const options = buildMySqlPoolOptions({
+      host: "127.0.0.1",
+      port: 3306,
+      user: "veil",
+      password: "veil",
+      database: "project_veil",
+      ssl: {
+        mode: "verify-ca",
+        caPath
+      },
+      pool: {
+        connectionLimit: 4,
+        maxIdle: 4,
+        idleTimeoutMs: 60_000,
+        queueLimit: 0,
+        waitForConnections: true
+      }
+    });
+
+    assert.deepEqual(options.ssl, {
+      rejectUnauthorized: true,
+      verifyIdentity: true,
+      ca: caBundle
+    });
+  } finally {
+    rmSync(tempDirectory, { recursive: true, force: true });
+  }
 });

--- a/apps/server/test/persistence-retention.test.ts
+++ b/apps/server/test/persistence-retention.test.ts
@@ -80,6 +80,35 @@ test("mysql persistence config reads explicit pool tuning from env", () => {
   assert.equal(config.pool.waitForConnections, false);
 });
 
+test("mysql persistence config reads SSL/TLS env settings", () => {
+  const config = readMySqlPersistenceConfig({
+    VEIL_MYSQL_HOST: "127.0.0.1",
+    VEIL_MYSQL_USER: "root",
+    VEIL_MYSQL_PASSWORD: "secret",
+    VEIL_MYSQL_SSL_MODE: "verify-ca",
+    VEIL_MYSQL_SSL_CA_PATH: "/var/run/project-veil/mysql/rds-ca.pem"
+  });
+
+  assert.ok(config);
+  assert.deepEqual(config.ssl, {
+    mode: "verify-ca",
+    caPath: "/var/run/project-veil/mysql/rds-ca.pem"
+  });
+});
+
+test("mysql persistence config refuses plaintext MySQL in production", () => {
+  assert.throws(
+    () =>
+      readMySqlPersistenceConfig({
+        VEIL_MYSQL_HOST: "127.0.0.1",
+        VEIL_MYSQL_USER: "root",
+        VEIL_MYSQL_PASSWORD: "secret",
+        NODE_ENV: "production"
+      }),
+    /VEIL_MYSQL_SSL_MODE/
+  );
+});
+
 test("snapshotHasExpired respects ttl windows", () => {
   const now = new Date("2026-03-20T12:00:00.000Z");
   const recent = new Date("2026-03-20T10:30:00.000Z");

--- a/apps/server/test/redis-client.test.ts
+++ b/apps/server/test/redis-client.test.ts
@@ -86,3 +86,23 @@ test("createRedisClient captures error events in runtime observability and logs 
   ]);
   assert.deepEqual(warnings, ["Redis client reconnect scheduled in 600ms."]);
 });
+
+test("createRedisClient redacts Redis credentials from runtime error detail", () => {
+  FakeRedisClient.instances.length = 0;
+  const runtimeDetails: string[] = [];
+
+  createRedisClient("redis://secure-user:hunter2@project-veil-redis:6379/0", {
+    RedisCtor: FakeRedisClient as never,
+    recordRuntimeErrorEvent: (event) => {
+      runtimeDetails.push(event.context.detail ?? "");
+    },
+    logger: { warn() {} }
+  });
+
+  const client = FakeRedisClient.instances[0];
+  client.emit("error", new Error("redis auth failed"));
+
+  assert.deepEqual(runtimeDetails, ["redis://project-veil-redis:6379/0"]);
+  assert.equal(runtimeDetails[0]?.includes("secure-user"), false);
+  assert.equal(runtimeDetails[0]?.includes("hunter2"), false);
+});

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -27,6 +27,8 @@ The server reads these variables on startup:
 | `VEIL_MYSQL_USER` | Yes | - | MySQL username |
 | `VEIL_MYSQL_PASSWORD` | Yes | - | MySQL password |
 | `VEIL_MYSQL_DATABASE` | No | `project_veil` | Database name |
+| `VEIL_MYSQL_SSL_MODE` | No | `disabled` | Transport mode for MySQL connections: `disabled`, `required`, or `verify-ca`. Production startup now rejects `disabled` so managed deployments must opt into TLS explicitly |
+| `VEIL_MYSQL_SSL_CA_PATH` | No | - | Optional PEM CA bundle path used when `VEIL_MYSQL_SSL_MODE=verify-ca`; omit it to use the runtime's default trust store |
 | `VEIL_MYSQL_POOL_CONNECTION_LIMIT` | No | `4` | Max concurrent connections opened by each Project Veil MySQL pool (`room_snapshot`, `config_center`, migration tooling) |
 | `VEIL_MYSQL_POOL_MAX_IDLE` | No | `4` | Max idle connections retained by each MySQL pool |
 | `VEIL_MYSQL_POOL_IDLE_TIMEOUT_MS` | No | `60000` | Idle-connection timeout for each MySQL pool |
@@ -40,6 +42,14 @@ The server reads these variables on startup:
 | `VEIL_DISPLAY_NAME_RULES_PATH` | No | `configs/display-name-rules.json` | Display-name moderation rules file path. The server hot-reloads this file without a redeploy |
 | `VEIL_DISPLAY_NAME_RULES_RELOAD_INTERVAL_MS` | No | `30000` | How often the server rechecks the display-name rules file for updates |
 | `VEIL_DISPLAY_NAME_RULES_JSON` | No | - | Optional JSON override for display-name moderation rules, useful for ops validation |
+
+### TLS modes
+
+- `disabled`: do not send an `ssl` option to mysql2. This remains acceptable for local development only.
+- `required`: encrypt transport, but do not verify the server certificate. Use this only as an intermediate step when the server presents a certificate chain the runtime does not trust yet.
+- `verify-ca`: encrypt transport and require certificate validation. If `VEIL_MYSQL_SSL_CA_PATH` is set, Project Veil reads that PEM bundle and passes it to mysql2; otherwise Node's default trust store is used.
+
+When `NODE_ENV=production`, Project Veil now rejects `VEIL_MYSQL_SSL_MODE=disabled` during MySQL config bootstrap so the server cannot silently fall back to plaintext database traffic.
 
 ## Database And Table
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,10 +28,13 @@ Pull requests that touch `k8s/` should also run `npm run validate -- k8s-image-t
 These manifests assume managed backing services instead of in-cluster MySQL:
 
 - `VEIL_MYSQL_HOST` points at an external RDS endpoint
+- `VEIL_MYSQL_SSL_MODE` should stay at `verify-ca` for managed MySQL so pod-to-RDS traffic is encrypted and certificate-validated
 - `REDIS_URL` points at an external Redis endpoint or dedicated Redis service
 - no MySQL `PersistentVolumeClaim` is included because the database is expected to live outside the cluster
 
 If you decide to run MySQL in-cluster instead, add a StatefulSet and PVC, then replace `VEIL_MYSQL_HOST` with the MySQL Service DNS name.
+
+If your container image does not already trust the managed MySQL server certificate chain, mount the CA bundle into the pod and set `VEIL_MYSQL_SSL_CA_PATH` to that PEM file.
 
 ## Secrets
 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -11,6 +11,8 @@ data:
   VEIL_MYSQL_PORT: "3306"
   VEIL_MYSQL_USER: project_veil
   VEIL_MYSQL_DATABASE: project_veil
+  VEIL_MYSQL_SSL_MODE: verify-ca
+  VEIL_MYSQL_SSL_CA_PATH: /var/run/project-veil/mysql/rds-ca.pem
   VEIL_MYSQL_POOL_QUEUE_LIMIT: "128"
   VEIL_MYSQL_POOL_WAIT_FOR_CONNECTIONS: "true"
   VEIL_MYSQL_SNAPSHOT_TTL_HOURS: "72"


### PR DESCRIPTION
Fixes #1644
Fixes #1645

- redact Redis URLs before runtime error reporting
- add MySQL SSL/TLS configuration and production-safe defaults
- update tests and deployment config