### PR TITLE
fix: throttle client runtime error reporting

### DIFF
--- a/apps/client/src/runtime-error-reporting.ts
+++ b/apps/client/src/runtime-error-reporting.ts
@@ -2,6 +2,11 @@ import { buildAuthHeaders } from "./auth-session";
 
 const DEFAULT_CLIENT_RUNTIME_PLATFORM = "h5-shell";
 const DEFAULT_CLIENT_RUNTIME_VERSION = "development";
+const CLIENT_RUNTIME_ERROR_DEDUPE_WINDOW_MS = 60_000;
+const CLIENT_RUNTIME_ERROR_THROTTLE_WINDOW_MS = 60_000;
+const CLIENT_RUNTIME_ERROR_THROTTLE_LIMIT = 5;
+const CLIENT_RUNTIME_ERROR_FINGERPRINT_STACK_LIMIT = 120;
+const CLIENT_RUNTIME_ERROR_RECENT_FINGERPRINT_LIMIT = 128;
 
 interface GlobalErrorBoundaryEventLike {
   message?: string;
@@ -73,6 +78,34 @@ function normalizeRuntimeBoundaryFailure(event: GlobalErrorBoundaryEventLike): {
   };
 }
 
+function buildRuntimeErrorFingerprint(input: { errorMessage: string; stack?: string }): string {
+  const stackPrefix = input.stack?.slice(0, CLIENT_RUNTIME_ERROR_FINGERPRINT_STACK_LIMIT).trim() ?? "";
+  return stackPrefix ? `${input.errorMessage}:${stackPrefix}` : input.errorMessage;
+}
+
+function pruneRecentRuntimeErrorFingerprints(recentFingerprints: Map<string, number>, now: number): void {
+  const cutoff = now - CLIENT_RUNTIME_ERROR_DEDUPE_WINDOW_MS;
+  for (const [fingerprint, reportedAt] of recentFingerprints.entries()) {
+    if (reportedAt < cutoff) {
+      recentFingerprints.delete(fingerprint);
+    }
+  }
+  while (recentFingerprints.size > CLIENT_RUNTIME_ERROR_RECENT_FINGERPRINT_LIMIT) {
+    const oldestFingerprint = recentFingerprints.keys().next().value;
+    if (typeof oldestFingerprint !== "string") {
+      break;
+    }
+    recentFingerprints.delete(oldestFingerprint);
+  }
+}
+
+function pruneRuntimeErrorReportTimestamps(reportTimestamps: number[], now: number): void {
+  const cutoff = now - CLIENT_RUNTIME_ERROR_THROTTLE_WINDOW_MS;
+  while (reportTimestamps.length > 0 && reportTimestamps[0] !== undefined && reportTimestamps[0] < cutoff) {
+    reportTimestamps.shift();
+  }
+}
+
 export async function reportClientRuntimeError({
   apiBaseUrl,
   authToken,
@@ -106,20 +139,55 @@ export function bindClientRuntimeErrorBoundary({
     return null;
   }
 
+  const recentFingerprints = new Map<string, number>();
+  const reportTimestamps: number[] = [];
+  let isHandlingRuntimeFailure = false;
+
   const handleRuntimeFailure = (event: GlobalErrorBoundaryEventLike): void => {
-    const normalized = normalizeRuntimeBoundaryFailure(event);
-    void reportClientRuntimeError({
-      apiBaseUrl,
-      authToken: readAuthToken(),
-      fetchImpl,
-      payload: {
+    if (isHandlingRuntimeFailure) {
+      return;
+    }
+
+    isHandlingRuntimeFailure = true;
+    try {
+      const normalized = normalizeRuntimeBoundaryFailure(event);
+      const now = Date.now();
+      const fingerprint = buildRuntimeErrorFingerprint(normalized);
+
+      pruneRecentRuntimeErrorFingerprints(recentFingerprints, now);
+      if (recentFingerprints.has(fingerprint)) {
+        return;
+      }
+
+      pruneRuntimeErrorReportTimestamps(reportTimestamps, now);
+      if (reportTimestamps.length >= CLIENT_RUNTIME_ERROR_THROTTLE_LIMIT) {
+        return;
+      }
+
+      const payload = {
         platform,
         version,
         errorMessage: normalized.errorMessage,
         ...(normalized.stack ? { stack: normalized.stack } : {}),
         context: readContext()
-      }
-    }).catch(() => undefined);
+      };
+      const authToken = readAuthToken();
+
+      recentFingerprints.set(fingerprint, now);
+      pruneRecentRuntimeErrorFingerprints(recentFingerprints, now);
+      reportTimestamps.push(now);
+
+      void reportClientRuntimeError({
+        apiBaseUrl,
+        authToken,
+        fetchImpl,
+        payload
+      }).catch(() => undefined);
+    } catch {
+      return;
+    } finally {
+      isHandlingRuntimeFailure = false;
+    }
   };
 
   eventTarget.addEventListener("error", handleRuntimeFailure);

--- a/apps/client/test/runtime-error-reporting.test.ts
+++ b/apps/client/test/runtime-error-reporting.test.ts
@@ -85,3 +85,158 @@ test("bindClientRuntimeErrorBoundary reports uncaught errors and rejections", as
   unbind?.();
   assert.equal(listeners.size, 0);
 });
+
+test("bindClientRuntimeErrorBoundary dedupes repeated runtime errors within the rolling window", async () => {
+  const listeners = new Map<string, (event: unknown) => void>();
+  const payloads: Array<Record<string, unknown>> = [];
+  const duplicateError = new Error("duplicate-boom");
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+
+  try {
+    const unbind = bindClientRuntimeErrorBoundary({
+      apiBaseUrl: "http://127.0.0.1:2567",
+      version: "test",
+      eventTarget: {
+        addEventListener(type, listener) {
+          listeners.set(type, listener);
+        },
+        removeEventListener(type) {
+          listeners.delete(type);
+        }
+      },
+      fetchImpl: (async (_url, init) => {
+        payloads.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 202 });
+      }) as typeof fetch,
+      readAuthToken: () => "session-token",
+      readContext: () => ({
+        roomId: "room-alpha"
+      })
+    });
+
+    for (let index = 0; index < 100; index += 1) {
+      listeners.get("error")?.({
+        error: duplicateError
+      });
+    }
+    await flushMicrotasks();
+
+    assert.equal(payloads.length, 1);
+    assert.equal(payloads[0]?.errorMessage, "duplicate-boom");
+
+    now += 61_000;
+    listeners.get("error")?.({
+      error: duplicateError
+    });
+    await flushMicrotasks();
+
+    assert.equal(payloads.length, 2);
+    unbind?.();
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("bindClientRuntimeErrorBoundary throttles unique runtime errors to five reports per minute", async () => {
+  const listeners = new Map<string, (event: unknown) => void>();
+  const payloads: Array<Record<string, unknown>> = [];
+  const originalNow = Date.now;
+  let now = 2_000;
+  Date.now = () => now;
+
+  try {
+    const unbind = bindClientRuntimeErrorBoundary({
+      apiBaseUrl: "http://127.0.0.1:2567",
+      version: "test",
+      eventTarget: {
+        addEventListener(type, listener) {
+          listeners.set(type, listener);
+        },
+        removeEventListener(type) {
+          listeners.delete(type);
+        }
+      },
+      fetchImpl: (async (_url, init) => {
+        payloads.push(JSON.parse(String(init?.body)));
+        return new Response(null, { status: 202 });
+      }) as typeof fetch,
+      readAuthToken: () => "session-token",
+      readContext: () => ({
+        roomId: "room-alpha"
+      })
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      listeners.get("error")?.({
+        error: new Error(`boom-${index}`)
+      });
+    }
+    await flushMicrotasks();
+
+    assert.equal(payloads.length, 5);
+
+    now += 61_000;
+    listeners.get("error")?.({
+      error: new Error("boom-after-window")
+    });
+    await flushMicrotasks();
+
+    assert.equal(payloads.length, 6);
+    unbind?.();
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("bindClientRuntimeErrorBoundary swallows handler failures before they can recurse", async () => {
+  const listeners = new Map<string, (event: unknown) => void>();
+  const payloads: Array<Record<string, unknown>> = [];
+  let recursiveDispatches = 0;
+  const unbind = bindClientRuntimeErrorBoundary({
+    apiBaseUrl: "http://127.0.0.1:2567",
+    version: "test",
+    eventTarget: {
+      addEventListener(type, listener) {
+        listeners.set(type, listener);
+      },
+      removeEventListener(type) {
+        listeners.delete(type);
+      }
+    },
+    fetchImpl: (async (_url, init) => {
+      payloads.push(JSON.parse(String(init?.body)));
+      return new Response(null, { status: 202 });
+    }) as typeof fetch,
+    readAuthToken: () => "session-token",
+    readContext: () => {
+      throw new Error("context-read-failed");
+    }
+  });
+
+  const emit = (type: string, event: unknown): void => {
+    const listener = listeners.get(type);
+    if (!listener) {
+      return;
+    }
+    try {
+      listener(event);
+    } catch (error) {
+      recursiveDispatches += 1;
+      if (recursiveDispatches < 5) {
+        emit("error", { error });
+      }
+    }
+  };
+
+  emit("unhandledrejection", {
+    reason: "async-boom"
+  });
+  await flushMicrotasks();
+
+  assert.equal(recursiveDispatches, 0);
+  assert.equal(payloads.length, 0);
+
+  unbind?.();
+});


### PR DESCRIPTION
Fixes #1646

- dedupe repeated runtime failures
- throttle client-side error reports per minute
- self-guard the boundary against recursive handler failures