### PR TITLE
fix: lock down admin and observability cors

### DIFF
--- a/apps/server/src/domain/ops/admin-console.ts
+++ b/apps/server/src/domain/ops/admin-console.ts
@@ -35,6 +35,7 @@ import {
 } from "@server/domain/ops/launch-runtime-state";
 import { recordLeaderboardAbuseAlert } from "@server/domain/ops/observability";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 
 class InvalidAdminJsonError extends Error {
   constructor() {
@@ -98,8 +99,7 @@ function readHeaderSecret(request: IncomingMessage): string | null {
 }
 
 function isAuthorized(request: IncomingMessage): boolean {
-  const adminSecret = readAdminSecret();
-  return adminSecret !== null && readHeaderSecret(request) === adminSecret;
+  return timingSafeCompareAdminToken(readHeaderSecret(request), readAdminSecret());
 }
 
 function readAdminRole(request: IncomingMessage): AdminRole | null {
@@ -108,13 +108,13 @@ function readAdminRole(request: IncomingMessage): AdminRole | null {
     return null;
   }
 
-  if (requestSecret === readAdminSecret()) {
+  if (timingSafeCompareAdminToken(requestSecret, readAdminSecret())) {
     return "admin";
   }
-  if (requestSecret === readSupportSupervisorSecret()) {
+  if (timingSafeCompareAdminToken(requestSecret, readSupportSupervisorSecret())) {
     return "support-supervisor";
   }
-  if (requestSecret === readSupportModeratorSecret()) {
+  if (timingSafeCompareAdminToken(requestSecret, readSupportModeratorSecret())) {
     return "support-moderator";
   }
   return null;
@@ -127,7 +127,6 @@ function hasRequiredRole(role: AdminRole | null, allowedRoles: AdminRole[]): boo
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
   response.setHeader("Content-Type", "application/json; charset=utf-8");
-  response.setHeader("Access-Control-Allow-Origin", "*");
   response.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
   response.setHeader("Access-Control-Allow-Headers", "Content-Type, x-veil-admin-secret");
   response.end(JSON.stringify(payload));
@@ -1151,7 +1150,6 @@ export function registerAdminRoutes(
   const guildService = new GuildService(store);
   app.use((request, response, next) => {
     if (request.method === "OPTIONS") {
-      response.setHeader("Access-Control-Allow-Origin", "*");
       response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
       response.setHeader("Access-Control-Allow-Headers", "Content-Type, x-veil-admin-secret");
       response.statusCode = 204;

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -2170,6 +2170,16 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.paymentGrant.counters.deadLetterTotal = 0;
 }
 
+const PUBLIC_RUNTIME_CORS_PATHS = new Set(["/api/runtime/health", "/api/runtime/auth-readiness"]);
+
+function readRequestPathname(request: IncomingMessage): string {
+  try {
+    return new URL(request.url ?? "/", "http://runtime.local").pathname;
+  } catch {
+    return "/";
+  }
+}
+
 export function registerRuntimeObservabilityRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
@@ -2187,9 +2197,15 @@ export function registerRuntimeObservabilityRoutes(
   const persistence = options?.persistence;
 
   app.use((request, response, next) => {
-    response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
-    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    if (PUBLIC_RUNTIME_CORS_PATHS.has(readRequestPathname(request))) {
+      response.setHeader("Access-Control-Allow-Origin", "*");
+      response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
+      response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    } else {
+      response.removeHeader("Access-Control-Allow-Origin");
+      response.removeHeader("Access-Control-Allow-Methods");
+      response.removeHeader("Access-Control-Allow-Headers");
+    }
 
     if (request.method === "OPTIONS") {
       response.statusCode = 204;

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -18,10 +18,13 @@ function createTestApp() {
   const gets = new Map<string, RouteHandler>();
   const posts = new Map<string, RouteHandler>();
   const deletes = new Map<string, RouteHandler>();
+  const uses: Array<(request: IncomingMessage, response: ServerResponse, next: () => void) => void> = [];
 
   return {
     app: {
-      use(_handler: any) {},
+      use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) {
+        uses.push(handler);
+      },
       get(path: string, handler: RouteHandler) {
         gets.set(path, handler);
       },
@@ -32,6 +35,7 @@ function createTestApp() {
         deletes.set(path, handler);
       }
     },
+    uses,
     gets,
     posts,
     deletes
@@ -149,9 +153,9 @@ async function withAnnouncementConfig(t: TestContext, payload: unknown): Promise
 }
 
 function registerRoutes(store: RoomSnapshotStore | null = null) {
-  const { app, gets, posts, deletes } = createTestApp();
+  const { app, uses, gets, posts, deletes } = createTestApp();
   registerAdminRoutes(app, store);
-  return { gets, posts, deletes };
+  return { uses, gets, posts, deletes };
 }
 
 function createStore(initialResourcesByPlayer: Record<string, { gold: number; wood: number; ore: number }> = {}) {
@@ -730,7 +734,41 @@ test("GET /api/admin/overview returns 401 without a valid admin secret", async (
   );
 
   assert.equal(response.statusCode, 401);
+  assert.equal(response.headers["Access-Control-Allow-Origin"], undefined);
   assert.deepEqual(JSON.parse(response.body), { error: "Unauthorized: Invalid Admin Secret" });
+});
+
+test("admin console auth uses timing-safe secret comparisons", async () => {
+  const sourcePath = fileURLToPath(new URL("../src/domain/ops/admin-console.ts", import.meta.url));
+  const source = await readFile(sourcePath, "utf8");
+
+  assert.match(source, /\btimingSafeCompareAdminToken\b/);
+  assert.doesNotMatch(source, /readHeaderSecret\(request\)\s*===\s*adminSecret/);
+  assert.doesNotMatch(source, /requestSecret\s*===\s*read(?:Admin|SupportSupervisor|SupportModerator)Secret\(\)/);
+});
+
+test("OPTIONS /api/admin preflight omits wildcard CORS exposure", async (t) => {
+  withAdminSecret(t);
+  const { uses } = registerRoutes();
+  const middleware = uses[0];
+  assert.ok(middleware);
+
+  const response = createResponse();
+  let nextCalled = false;
+  await middleware(
+    createRequest({
+      method: "OPTIONS",
+      url: "/api/admin/overview"
+    }),
+    response,
+    () => {
+      nextCalled = true;
+    }
+  );
+
+  assert.equal(nextCalled, false);
+  assert.equal(response.statusCode, 204);
+  assert.equal(response.headers["Access-Control-Allow-Origin"], undefined);
 });
 
 test("GET /api/admin/overview returns server overview payload with a valid admin secret", async (t) => {
@@ -758,6 +796,7 @@ test("GET /api/admin/overview returns server overview payload with a valid admin
   };
 
   assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["Access-Control-Allow-Origin"], undefined);
   assert.equal(payload.activeRooms, 0);
   assert.equal(payload.activePlayers, 0);
   assert.equal(payload.nodeVersion, process.version);

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -312,6 +312,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   };
 
   assert.equal(healthResponse.status, 200);
+  assert.equal(healthResponse.headers.get("access-control-allow-origin"), "*");
   assert.equal(healthPayload.status, "ok");
   assert.equal(healthPayload.runtime.activeRoomCount, 1);
   assert.equal(healthPayload.runtime.connectionCount, 1);
@@ -334,6 +335,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   };
 
   assert.equal(readinessResponse.status, 200);
+  assert.equal(readinessResponse.headers.get("access-control-allow-origin"), "*");
   assert.equal(readinessPayload.status, "ok");
   assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
 
@@ -424,6 +426,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   };
 
   assert.equal(diagnosticResponse.status, 200);
+  assert.equal(diagnosticResponse.headers.get("access-control-allow-origin"), null);
   assert.equal(diagnosticPayload.source.surface, "server-observability");
   assert.equal(diagnosticPayload.source.mode, "server");
   assert.equal(diagnosticPayload.room, null);
@@ -442,6 +445,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   const diagnosticText = await diagnosticTextResponse.text();
 
   assert.equal(diagnosticTextResponse.status, 200);
+  assert.equal(diagnosticTextResponse.headers.get("access-control-allow-origin"), null);
   assert.match(diagnosticTextResponse.headers.get("content-type") ?? "", /^text\/plain/);
   assert.match(diagnosticText, /Mode server \(server-observability\)/);
   assert.match(diagnosticText, /Runtime rooms 1 \/ connections 1 \/ battles 0/);
@@ -452,6 +456,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   const metricsText = await metricsResponse.text();
 
   assert.equal(metricsResponse.status, 200);
+  assert.equal(metricsResponse.headers.get("access-control-allow-origin"), null);
   assert.match(metricsResponse.headers.get("content-type") ?? "", /^text\/plain/);
   assert.match(metricsText, /^veil_up 1$/m);
   assert.match(metricsText, /^veil_active_rooms_total 1$/m);
@@ -500,6 +505,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   };
 
   assert.equal(roomLifecycleResponse.status, 200);
+  assert.equal(roomLifecycleResponse.headers.get("access-control-allow-origin"), null);
   assert.equal(roomLifecyclePayload.status, "ok");
   assert.match(roomLifecyclePayload.headline, /created=1/);
   assert.equal(roomLifecyclePayload.summary.activeRoomCount, 1);
@@ -517,6 +523,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   const roomLifecycleText = await roomLifecycleTextResponse.text();
 
   assert.equal(roomLifecycleTextResponse.status, 200);
+  assert.equal(roomLifecycleTextResponse.headers.get("access-control-allow-origin"), null);
   assert.match(roomLifecycleTextResponse.headers.get("content-type") ?? "", /^text\/plain/);
   assert.match(roomLifecycleText, /^room_lifecycle status=ok/m);
   assert.match(roomLifecycleText, /room_creates=1/);
@@ -563,6 +570,13 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(analyticsPipelineText, /^analytics_pipeline status=ok/m);
   assert.match(analyticsPipelineText, /dataset=analytics_prod\.veil_analytics_events/);
   assert.match(analyticsPipelineText, /deletion_workflow=dsr-player-delete/);
+
+  const healthPreflightResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/health`, {
+    method: "OPTIONS"
+  });
+
+  assert.equal(healthPreflightResponse.status, 204);
+  assert.equal(healthPreflightResponse.headers.get("access-control-allow-origin"), "*");
 
   const prometheusResponse = await fetch(`http://127.0.0.1:${port}/metrics`);
   const prometheusText = await prometheusResponse.text();


### PR DESCRIPTION
Fixes #1640
Fixes #1642

- replace remaining admin secret equality checks with timing-safe comparison
- remove wildcard CORS from sensitive admin and runtime observability endpoints
- add focused regression coverage