### PR TITLE
Require admin auth for config read routes

### DIFF
--- a/apps/server/src/domain/config-center/routes.ts
+++ b/apps/server/src/domain/config-center/routes.ts
@@ -53,6 +53,16 @@ function protectMutatingRoute(handler: ConfigCenterRouteHandler): ConfigCenterRo
   };
 }
 
+function protectAdminRoute(handler: ConfigCenterRouteHandler): ConfigCenterRouteHandler {
+  return async (request, response) => {
+    if (!requireConfigCenterAdminToken(request, response)) {
+      return;
+    }
+
+    await handler(request, response);
+  };
+}
+
 export function registerConfigCenterRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
@@ -62,7 +72,7 @@ export function registerConfigCenterRoutes(
   },
   store: ConfigCenterStore
 ): void {
-  app.get("/api/config-center/configs", async (_request, response) => {
+  app.get("/api/config-center/configs", protectAdminRoute(async (_request, response) => {
     try {
       sendJson(response, 200, {
         storage: store.mode,
@@ -71,9 +81,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/configs/:id", async (request, response) => {
+  app.get("/api/config-center/configs/:id", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     if (!configId) {
       sendNotFound(response);
@@ -94,9 +104,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/configs/:id/diff-preview", async (request, response) => {
+  app.get("/api/config-center/configs/:id/diff-preview", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -112,9 +122,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.post("/api/config-center/configs/:id/preview", async (request, response) => {
+  app.post("/api/config-center/configs/:id/preview", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     if (configId !== "world") {
       sendJson(response, 404, {
@@ -150,9 +160,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.post("/api/config-center/configs/:id/validate", async (request, response) => {
+  app.post("/api/config-center/configs/:id/validate", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -179,9 +189,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/configs/:id/snapshots", async (request, response) => {
+  app.get("/api/config-center/configs/:id/snapshots", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -202,9 +212,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/publish-stage", async (_request, response) => {
+  app.get("/api/config-center/publish-stage", protectAdminRoute(async (_request, response) => {
     try {
       sendJson(response, 200, {
         storage: store.mode,
@@ -213,9 +223,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/publish-history", async (_request, response) => {
+  app.get("/api/config-center/publish-history", protectAdminRoute(async (_request, response) => {
     try {
       sendJson(response, 200, {
         storage: store.mode,
@@ -224,7 +234,7 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
   app.put("/api/config-center/publish-stage", protectMutatingRoute(async (request, response) => {
     try {
@@ -358,7 +368,7 @@ export function registerConfigCenterRoutes(
     }
   }));
 
-  app.post("/api/config-center/configs/:id/diff", async (request, response) => {
+  app.post("/api/config-center/configs/:id/diff", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -385,9 +395,9 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
-  app.get("/api/config-center/configs/:id/presets", async (request, response) => {
+  app.get("/api/config-center/configs/:id/presets", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -403,7 +413,7 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
   app.post("/api/config-center/configs/:id/presets", protectMutatingRoute(async (request, response) => {
     const configId = request.params.id;
@@ -453,7 +463,7 @@ export function registerConfigCenterRoutes(
     }
   }));
 
-  app.get("/api/config-center/configs/:id/export", async (request, response) => {
+  app.get("/api/config-center/configs/:id/export", protectAdminRoute(async (request, response) => {
     const configId = request.params.id;
     const definition = configId ? configDefinitionFor(configId) : undefined;
     if (!definition) {
@@ -474,7 +484,7 @@ export function registerConfigCenterRoutes(
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
-  });
+  }));
 
   app.post("/api/config-center/configs/:id/import", protectMutatingRoute(async (request, response) => {
     const configId = request.params.id;

--- a/apps/server/src/transport/http/config-viewer.ts
+++ b/apps/server/src/transport/http/config-viewer.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ConfigCenterStore, ConfigDocumentId, ConfigDocumentSummary } from "@server/config-center";
+import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -47,7 +49,34 @@ function normalizeSummaryItem(item: ConfigDocumentSummary) {
   };
 }
 
-function buildViewerHtml(): string {
+function requireConfigViewerAdminToken(request: IncomingMessage, response: ServerResponse): string | null {
+  const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+  if (!adminToken) {
+    sendJson(response, 503, {
+      error: {
+        code: "not_configured",
+        message: "Admin token not configured"
+      }
+    });
+    return null;
+  }
+
+  const headerValue = request.headers["x-veil-admin-token"];
+  const requestToken = Array.isArray(headerValue) ? headerValue[0]?.trim() ?? null : headerValue?.trim() ?? null;
+  if (!timingSafeCompareAdminToken(requestToken, adminToken)) {
+    sendJson(response, 403, {
+      error: {
+        code: "forbidden",
+        message: "Invalid admin token"
+      }
+    });
+    return null;
+  }
+
+  return requestToken;
+}
+
+function buildViewerHtml(adminToken?: string): string {
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -267,6 +296,7 @@ function buildViewerHtml(): string {
     <script>
       const statusNode = document.getElementById("status");
       const listNode = document.getElementById("list");
+      const adminToken = ${JSON.stringify(adminToken ?? "")};
 
       function setStatus(message, isError) {
         statusNode.textContent = message;
@@ -298,7 +328,9 @@ function buildViewerHtml(): string {
         button.textContent = "Loading...";
 
         try {
-          const response = await fetch("/api/config/" + encodeURIComponent(item.id));
+          const response = await fetch("/api/config/" + encodeURIComponent(item.id), {
+            headers: adminToken ? { "x-veil-admin-token": adminToken } : {}
+          });
           const payload = await response.json();
           if (!response.ok) {
             throw new Error(payload && payload.error && payload.error.message ? payload.error.message : "Request failed");
@@ -384,7 +416,9 @@ function buildViewerHtml(): string {
 
       async function load() {
         try {
-          const response = await fetch("/api/config");
+          const response = await fetch("/api/config", {
+            headers: adminToken ? { "x-veil-admin-token": adminToken } : {}
+          });
           const payload = await response.json();
           if (!response.ok) {
             throw new Error(payload && payload.error && payload.error.message ? payload.error.message : "Failed to load config list");
@@ -412,11 +446,21 @@ export function registerConfigViewerRoutes(
   },
   store: ConfigCenterStore
 ): void {
-  app.get("/config-viewer", (_request, response) => {
-    sendHtml(response, buildViewerHtml());
+  app.get("/config-viewer", (request, response) => {
+    const adminToken = requireConfigViewerAdminToken(request, response);
+    if (!adminToken) {
+      return;
+    }
+
+    sendHtml(response, buildViewerHtml(adminToken));
   });
 
-  app.get("/api/config", async (_request, response) => {
+  app.get("/api/config", async (request, response) => {
+    const adminToken = requireConfigViewerAdminToken(request, response);
+    if (!adminToken) {
+      return;
+    }
+
     try {
       const items = await store.listDocuments();
       sendJson(response, 200, {
@@ -428,6 +472,11 @@ export function registerConfigViewerRoutes(
   });
 
   app.get("/api/config/:id", async (request, response) => {
+    const adminToken = requireConfigViewerAdminToken(request, response);
+    if (!adminToken) {
+      return;
+    }
+
     const configId = request.params.id as ConfigDocumentId | undefined;
     if (!configId) {
       sendNotFound(response);

--- a/apps/server/test/config-center-routes.test.ts
+++ b/apps/server/test/config-center-routes.test.ts
@@ -97,6 +97,18 @@ function withAdminToken(t: TestContext, token = "config-center-admin-token"): st
   return token;
 }
 
+function withMissingAdminToken(t: TestContext): void {
+  const original = process.env.VEIL_ADMIN_TOKEN;
+  delete process.env.VEIL_ADMIN_TOKEN;
+  t.after(() => {
+    if (original === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = original;
+  });
+}
+
 function createStore() {
   const savedDocuments: Array<{ id: string; content: string }> = [];
   const documents = new Map<string, string>([
@@ -187,33 +199,110 @@ function registerRoutes(store: ConfigCenterStore) {
   return { gets, posts, puts, uses };
 }
 
-test("config-center keeps read-only routes public and does not emit wildcard CORS headers", async () => {
+test("config-center read routes require the admin token", async (t) => {
+  withMissingAdminToken(t);
   const { store } = createStore();
   const { gets, posts, uses } = registerRoutes(store);
-  const listHandler = gets.get("/api/config-center/configs");
-  const validateHandler = posts.get("/api/config-center/configs/:id/validate");
-  const listResponse = createResponse();
-  const validateResponse = createResponse();
+  const routes: Array<{
+    method: "get" | "post";
+    path: string;
+    params?: Record<string, string>;
+    body?: string;
+    url: string;
+  }> = [
+    {
+      method: "get",
+      path: "/api/config-center/configs",
+      url: "/api/config-center/configs"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/configs/:id",
+      params: { id: "world" },
+      url: "/api/config-center/configs/world"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/configs/:id/diff-preview",
+      params: { id: "world" },
+      url: "/api/config-center/configs/world/diff-preview"
+    },
+    {
+      method: "post",
+      path: "/api/config-center/configs/:id/preview",
+      params: { id: "world" },
+      body: JSON.stringify({ content: "{\"width\":8}" }),
+      url: "/api/config-center/configs/world/preview"
+    },
+    {
+      method: "post",
+      path: "/api/config-center/configs/:id/validate",
+      params: { id: "world" },
+      body: JSON.stringify({ content: "{\"width\":8}" }),
+      url: "/api/config-center/configs/world/validate"
+    },
+    {
+      method: "post",
+      path: "/api/config-center/configs/:id/diff",
+      params: { id: "world" },
+      body: JSON.stringify({ snapshotId: "snapshot-1" }),
+      url: "/api/config-center/configs/world/diff"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/configs/:id/snapshots",
+      params: { id: "world" },
+      url: "/api/config-center/configs/world/snapshots"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/publish-stage",
+      url: "/api/config-center/publish-stage"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/publish-history",
+      url: "/api/config-center/publish-history"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/configs/:id/presets",
+      params: { id: "world" },
+      url: "/api/config-center/configs/world/presets"
+    },
+    {
+      method: "get",
+      path: "/api/config-center/configs/:id/export",
+      params: { id: "world" },
+      url: "/api/config-center/configs/world/export"
+    }
+  ];
 
   assert.equal(uses.length, 0);
-  assert.ok(listHandler);
-  assert.ok(validateHandler);
+  for (const route of routes) {
+    const handler = route.method === "get" ? gets.get(route.path) : posts.get(route.path);
+    const response = createResponse();
+    assert.ok(handler, `expected handler for ${route.method.toUpperCase()} ${route.path}`);
+    await handler(
+      createRequest({
+        method: route.method.toUpperCase(),
+        headers: {},
+        params: route.params,
+        body: route.body,
+        url: route.url
+      }),
+      response
+    );
 
-  await listHandler(createRequest({ url: "/api/config-center/configs" }), listResponse);
-  await validateHandler(
-    createRequest({
-      method: "POST",
-      url: "/api/config-center/configs/world/validate",
-      params: { id: "world" },
-      body: JSON.stringify({ content: "{\"width\":8}" })
-    }),
-    validateResponse
-  );
-
-  assert.equal(listResponse.statusCode, 200);
-  assert.equal(listResponse.headers["Access-Control-Allow-Origin"], undefined);
-  assert.equal(validateResponse.statusCode, 200);
-  assert.equal(validateResponse.headers["Access-Control-Allow-Origin"], undefined);
+    assert.equal(response.statusCode, 503, `${route.method.toUpperCase()} ${route.path}`);
+    assert.deepEqual(JSON.parse(response.body), {
+      error: {
+        code: "not_configured",
+        message: "Admin token not configured"
+      }
+    });
+    assert.equal(response.headers["Access-Control-Allow-Origin"], undefined);
+  }
 });
 
 test("config-center mutating routes return 503 when VEIL_ADMIN_TOKEN is not configured", async () => {
@@ -260,6 +349,43 @@ test("config-center mutating routes return 503 when VEIL_ADMIN_TOKEN is not conf
   }
 
   assert.deepEqual(savedDocuments, []);
+});
+
+test("config-center read routes accept a valid admin token", async (t) => {
+  const token = withAdminToken(t);
+  const { store } = createStore();
+  const { gets, posts } = registerRoutes(store);
+
+  const listHandler = gets.get("/api/config-center/configs");
+  const validateHandler = posts.get("/api/config-center/configs/:id/validate");
+  const listResponse = createResponse();
+  const validateResponse = createResponse();
+
+  assert.ok(listHandler);
+  assert.ok(validateHandler);
+
+  await listHandler(
+    createRequest({
+      url: "/api/config-center/configs",
+      headers: { "x-veil-admin-token": token }
+    }),
+    listResponse
+  );
+  await validateHandler(
+    createRequest({
+      method: "POST",
+      url: "/api/config-center/configs/world/validate",
+      params: { id: "world" },
+      headers: { "x-veil-admin-token": token },
+      body: JSON.stringify({ content: "{\"width\":8}" })
+    }),
+    validateResponse
+  );
+
+  assert.equal(listResponse.statusCode, 200);
+  assert.equal(listResponse.headers["Access-Control-Allow-Origin"], undefined);
+  assert.equal(validateResponse.statusCode, 200);
+  assert.equal(validateResponse.headers["Access-Control-Allow-Origin"], undefined);
 });
 
 test("config-center mutating routes reject invalid admin tokens and accept valid ones", async (t) => {

--- a/apps/server/test/config-viewer.test.ts
+++ b/apps/server/test/config-viewer.test.ts
@@ -141,12 +141,26 @@ async function startConfigViewerServer(port: number, rootDir: string): Promise<{
   return { server, store };
 }
 
+function withAdminToken(t: import("node:test").TestContext, token = "config-viewer-admin-token"): string {
+  const original = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = token;
+  t.after(() => {
+    if (original === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = original;
+    }
+  });
+  return token;
+}
+
 test("config viewer page includes plain fetch-driven shell", () => {
   const html = buildConfigViewerPageForTest();
 
   assert.match(html, /Config Viewer/);
-  assert.match(html, /fetch\("\/api\/config"\)/);
-  assert.match(html, /fetch\("\/api\/config\/" \+ encodeURIComponent\(item.id\)\)/);
+  assert.match(html, /const adminToken = "";/);
+  assert.match(html, /fetch\("\/api\/config", \{\s*headers: adminToken \? \{ "x-veil-admin-token": adminToken \} : \{\}\s*\}\)/s);
+  assert.match(html, /fetch\("\/api\/config\/" \+ encodeURIComponent\(item.id\), \{\s*headers: adminToken \? \{ "x-veil-admin-token": adminToken \} : \{\}\s*\}\)/s);
 });
 
 test("config viewer exposes list and detail aliases plus html page", async (t) => {
@@ -160,13 +174,19 @@ test("config viewer exposes list and detail aliases plus html page", async (t) =
     await store.close();
   });
 
-  const pageResponse = await fetch(`http://127.0.0.1:${port}/config-viewer`);
+  const token = withAdminToken(t);
+
+  const pageResponse = await fetch(`http://127.0.0.1:${port}/config-viewer`, {
+    headers: { "x-veil-admin-token": token }
+  });
   const pageHtml = await pageResponse.text();
   assert.equal(pageResponse.status, 200);
   assert.match(pageResponse.headers.get("content-type") ?? "", /text\/html/);
   assert.match(pageHtml, /Loading config documents/);
 
-  const listResponse = await fetch(`http://127.0.0.1:${port}/api/config`);
+  const listResponse = await fetch(`http://127.0.0.1:${port}/api/config`, {
+    headers: { "x-veil-admin-token": token }
+  });
   const listPayload = (await listResponse.json()) as {
     items: Array<{
       id: string;
@@ -185,7 +205,9 @@ test("config viewer exposes list and detail aliases plus html page", async (t) =
   );
   assert.ok(listPayload.items.every((item) => item.updatedAt && item.summary && item.storage && item.version >= 1));
 
-  const detailResponse = await fetch(`http://127.0.0.1:${port}/api/config/world`);
+  const detailResponse = await fetch(`http://127.0.0.1:${port}/api/config/world`, {
+    headers: { "x-veil-admin-token": token }
+  });
   const detailPayload = (await detailResponse.json()) as {
     document: {
       id: string;
@@ -205,6 +227,28 @@ test("config viewer exposes list and detail aliases plus html page", async (t) =
   assert.equal(detailPayload.document.content.width, 8);
   assert.equal(detailPayload.document.content.height, 8);
 
-  const missingResponse = await fetch(`http://127.0.0.1:${port}/api/config/missing`);
+  const missingResponse = await fetch(`http://127.0.0.1:${port}/api/config/missing`, {
+    headers: { "x-veil-admin-token": token }
+  });
   assert.equal(missingResponse.status, 404);
+});
+
+test("config viewer routes reject missing admin tokens", async (t) => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-viewer-"));
+  await seedConfigRoot(rootDir);
+  const port = 43500 + Math.floor(Math.random() * 1000);
+  const { server, store } = await startConfigViewerServer(port, rootDir);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+    await store.close();
+  });
+
+  const pageResponse = await fetch(`http://127.0.0.1:${port}/config-viewer`);
+  const listResponse = await fetch(`http://127.0.0.1:${port}/api/config`);
+  const detailResponse = await fetch(`http://127.0.0.1:${port}/api/config/world`);
+
+  assert.equal(pageResponse.status, 503);
+  assert.equal(listResponse.status, 503);
+  assert.equal(detailResponse.status, 503);
 });


### PR DESCRIPTION
Closes #1669.\n\n- Protect config-center and config-viewer read routes with admin token auth.\n- Preserve mutating route auth behavior.\n- Add coverage for missing and valid admin tokens.\n\nVerification:\n- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/server/test/config-center-routes.test.ts apps/server/test/config-viewer.test.ts