### PR TITLE
Harden runtime ops endpoints

### DIFF
--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -10,6 +10,7 @@ import {
 import { getMySqlPoolMetricsSnapshot, resetTrackedMySqlPools } from "@server/infra/mysql-pool";
 import { resetGuestAuthSessions } from "@server/domain/account/auth";
 import { configureAuthoritativeRoomTelemetry } from "@server/index";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 import { getActiveRoomInstances, resetLobbyRoomRegistry } from "@server/transport/colyseus-room/runtime";
 
@@ -2170,7 +2171,52 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.paymentGrant.counters.deadLetterTotal = 0;
 }
 
-const PUBLIC_RUNTIME_CORS_PATHS = new Set(["/api/runtime/health", "/api/runtime/auth-readiness"]);
+const PUBLIC_RUNTIME_CORS_PATHS = new Set(["/api/runtime/health"]);
+
+function sendAdminTokenNotConfigured(response: ServerResponse): void {
+  sendJson(response, 503, {
+    error: {
+      code: "admin_token_not_configured",
+      message: "VEIL_ADMIN_TOKEN is not configured"
+    }
+  });
+}
+
+function sendInvalidAdminToken(response: ServerResponse): void {
+  sendJson(response, 403, {
+    error: {
+      code: "forbidden",
+      message: "Invalid admin token"
+    }
+  });
+}
+
+function requireRuntimeAdminToken(request: IncomingMessage, response: ServerResponse): boolean {
+  const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+  if (!adminToken) {
+    sendAdminTokenNotConfigured(response);
+    return false;
+  }
+
+  if (!timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken)) {
+    sendInvalidAdminToken(response);
+    return false;
+  }
+
+  return true;
+}
+
+function protectRuntimeRoute(
+  handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>
+): (request: IncomingMessage, response: ServerResponse) => void | Promise<void> {
+  return async (request, response) => {
+    if (!requireRuntimeAdminToken(request, response)) {
+      return;
+    }
+
+    await handler(request, response);
+  };
+}
 
 function readRequestPathname(request: IncomingMessage): string {
   try {
@@ -2190,6 +2236,7 @@ export function registerRuntimeObservabilityRoutes(
     serviceName?: string;
     store?: { clearAll?: () => void };
     persistence?: RuntimePersistenceHealth;
+    enableTestRoutes?: boolean;
   }
 ): void {
   const serviceName = options?.serviceName ?? "project-veil-server";
@@ -2225,152 +2272,185 @@ export function registerRuntimeObservabilityRoutes(
     }
   });
 
-  app.get("/api/runtime/metrics", async (_request, response) => {
-    try {
-      response.statusCode = 200;
-      response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-      response.end(`${buildPrometheusMetricsDocument()}\n`);
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/room-lifecycle-summary", async (request, response) => {
-    try {
-      const summary = buildRoomLifecycleSummaryPayload(serviceName);
-      const url = new URL(request.url ?? "/api/runtime/room-lifecycle-summary", "http://runtime.local");
-
-      if (url.searchParams.get("format") === "text") {
+  app.get(
+    "/api/runtime/metrics",
+    protectRuntimeRoute(async (_request, response) => {
+      try {
         response.statusCode = 200;
-        response.setHeader("Content-Type", "text/plain; charset=utf-8");
-        response.end(renderRoomLifecycleSummaryText(summary));
-        return;
+        response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+        response.end(`${buildPrometheusMetricsDocument()}\n`);
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
       }
+    })
+  );
 
-      sendJson(response, 200, summary);
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
+  app.get(
+    "/api/runtime/room-lifecycle-summary",
+    protectRuntimeRoute(async (request, response) => {
+      try {
+        const summary = buildRoomLifecycleSummaryPayload(serviceName);
+        const url = new URL(request.url ?? "/api/runtime/room-lifecycle-summary", "http://runtime.local");
 
-  app.get("/api/runtime/auth-readiness", async (_request, response) => {
-    try {
-      sendJson(response, 200, buildAuthReadinessPayload(serviceName));
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/diagnostic-snapshot", async (request, response) => {
-    try {
-      const snapshot = buildRuntimeDiagnosticSnapshot(serviceName);
-      const url = new URL(request.url ?? "/api/runtime/diagnostic-snapshot", "http://runtime.local");
-
-      if (url.searchParams.get("format") === "text") {
-        response.statusCode = 200;
-        response.setHeader("Content-Type", "text/plain; charset=utf-8");
-        response.end(`${renderRuntimeDiagnosticsSnapshotText(snapshot)}\n`);
-        return;
-      }
-
-      sendJson(response, 200, snapshot);
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/account-token-delivery", async (_request, response) => {
-    try {
-      sendJson(response, 200, buildAuthTokenDeliveryPayload(serviceName));
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/analytics-pipeline", async (request, response) => {
-    try {
-      const snapshot = getAnalyticsPipelineSnapshot();
-      const url = new URL(request.url ?? "/api/runtime/analytics-pipeline", "http://runtime.local");
-
-      if (url.searchParams.get("format") === "text") {
-        response.statusCode = 200;
-        response.setHeader("Content-Type", "text/plain; charset=utf-8");
-        response.end(renderAnalyticsPipelineSnapshotText(snapshot));
-        return;
-      }
-
-      sendJson(response, 200, snapshot);
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/feature-flags", async (_request, response) => {
-    try {
-      sendJson(response, 200, buildFeatureFlagObservabilityPayload(serviceName));
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/kill-switches", async (_request, response) => {
-    try {
-      sendJson(response, 200, buildRuntimeKillSwitchPayload(serviceName));
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  app.get("/api/runtime/slo-summary", async (request, response) => {
-    try {
-      const summary = buildRuntimeSloSummaryPayload(serviceName);
-      const url = new URL(request.url ?? "/api/runtime/slo-summary", "http://runtime.local");
-
-      if (url.searchParams.get("format") === "markdown") {
-        response.statusCode = 200;
-        response.setHeader("Content-Type", "text/markdown; charset=utf-8");
-        response.end(renderRuntimeSloSummaryMarkdown(summary));
-        return;
-      }
-
-      if (url.searchParams.get("format") === "text") {
-        response.statusCode = 200;
-        response.setHeader("Content-Type", "text/plain; charset=utf-8");
-        response.end(renderRuntimeSloSummaryText(summary));
-        return;
-      }
-
-      sendJson(response, 200, summary);
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
-
-  // Test-only endpoint to reset in-memory state
-  app.post("/api/test/reset-store", async (_request, response) => {
-    try {
-      if (store?.clearAll) {
-        const activeRooms = Array.from(getActiveRoomInstances().values());
-        for (const room of activeRooms) {
-          await room.disconnect().catch((error: unknown) => {
-            console.warn("[test-reset] failed to disconnect active room", {
-              roomId: room.roomId,
-              error
-            });
-          });
+        if (url.searchParams.get("format") === "text") {
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.end(renderRoomLifecycleSummaryText(summary));
+          return;
         }
-        resetLobbyRoomRegistry();
-        store.clearAll();
-        resetCapturedAnalyticsEventsForTest();
-        // Also reset guest auth sessions to clear cached tokens/sessions
-        // that were persisted in module-level maps in auth.ts
-        resetGuestAuthSessions();
-        sendJson(response, 200, { status: "ok", message: "Store and auth sessions cleared" });
-      } else {
-        sendJson(response, 400, { error: { message: "Store does not support clearing" } });
+
+        sendJson(response, 200, summary);
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
       }
-    } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
-    }
-  });
+    })
+  );
+
+  app.get(
+    "/api/runtime/auth-readiness",
+    protectRuntimeRoute(async (_request, response) => {
+      try {
+        sendJson(response, 200, buildAuthReadinessPayload(serviceName));
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/diagnostic-snapshot",
+    protectRuntimeRoute(async (request, response) => {
+      try {
+        const snapshot = buildRuntimeDiagnosticSnapshot(serviceName);
+        const url = new URL(request.url ?? "/api/runtime/diagnostic-snapshot", "http://runtime.local");
+
+        if (url.searchParams.get("format") === "text") {
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.end(`${renderRuntimeDiagnosticsSnapshotText(snapshot)}\n`);
+          return;
+        }
+
+        sendJson(response, 200, snapshot);
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/account-token-delivery",
+    protectRuntimeRoute(async (_request, response) => {
+      try {
+        sendJson(response, 200, buildAuthTokenDeliveryPayload(serviceName));
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/analytics-pipeline",
+    protectRuntimeRoute(async (request, response) => {
+      try {
+        const snapshot = getAnalyticsPipelineSnapshot();
+        const url = new URL(request.url ?? "/api/runtime/analytics-pipeline", "http://runtime.local");
+
+        if (url.searchParams.get("format") === "text") {
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.end(renderAnalyticsPipelineSnapshotText(snapshot));
+          return;
+        }
+
+        sendJson(response, 200, snapshot);
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/feature-flags",
+    protectRuntimeRoute(async (_request, response) => {
+      try {
+        sendJson(response, 200, buildFeatureFlagObservabilityPayload(serviceName));
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/kill-switches",
+    protectRuntimeRoute(async (_request, response) => {
+      try {
+        sendJson(response, 200, buildRuntimeKillSwitchPayload(serviceName));
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  app.get(
+    "/api/runtime/slo-summary",
+    protectRuntimeRoute(async (request, response) => {
+      try {
+        const summary = buildRuntimeSloSummaryPayload(serviceName);
+        const url = new URL(request.url ?? "/api/runtime/slo-summary", "http://runtime.local");
+
+        if (url.searchParams.get("format") === "markdown") {
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "text/markdown; charset=utf-8");
+          response.end(renderRuntimeSloSummaryMarkdown(summary));
+          return;
+        }
+
+        if (url.searchParams.get("format") === "text") {
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.end(renderRuntimeSloSummaryText(summary));
+          return;
+        }
+
+        sendJson(response, 200, summary);
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    })
+  );
+
+  if (options?.enableTestRoutes) {
+    // Test-only endpoint to reset in-memory state
+    app.post("/api/test/reset-store", async (request, response) => {
+      if (!requireRuntimeAdminToken(request, response)) {
+        return;
+      }
+
+      try {
+        if (store?.clearAll) {
+          const activeRooms = Array.from(getActiveRoomInstances().values());
+          for (const room of activeRooms) {
+            await room.disconnect().catch((error: unknown) => {
+              console.warn("[test-reset] failed to disconnect active room", {
+                roomId: room.roomId,
+                error
+              });
+            });
+          }
+          resetLobbyRoomRegistry();
+          store.clearAll();
+          resetCapturedAnalyticsEventsForTest();
+          // Also reset guest auth sessions to clear cached tokens/sessions
+          // that were persisted in module-level maps in auth.ts
+          resetGuestAuthSessions();
+          sendJson(response, 200, { status: "ok", message: "Store and auth sessions cleared" });
+        } else {
+          sendJson(response, 400, { error: { message: "Store does not support clearing" } });
+        }
+      } catch (error) {
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    });
+  }
 }

--- a/apps/server/src/domain/ops/retention-summary.ts
+++ b/apps/server/src/domain/ops/retention-summary.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RoomSnapshotStore } from "@server/persistence";
+import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 
 interface RetentionSummaryHttpApp {
   get(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
@@ -20,6 +22,31 @@ function sendJson(response: ServerResponse, statusCode: number, payload: unknown
   response.statusCode = statusCode;
   response.setHeader("Content-Type", "application/json; charset=utf-8");
   response.end(JSON.stringify(payload));
+}
+
+function requireRetentionSummaryAdminToken(request: IncomingMessage, response: ServerResponse): boolean {
+  const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+  if (!adminToken) {
+    sendJson(response, 503, {
+      error: {
+        code: "admin_token_not_configured",
+        message: "VEIL_ADMIN_TOKEN is not configured"
+      }
+    });
+    return false;
+  }
+
+  if (!timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken)) {
+    sendJson(response, 403, {
+      error: {
+        code: "forbidden",
+        message: "Invalid admin token"
+      }
+    });
+    return false;
+  }
+
+  return true;
 }
 
 function toIsoDate(input?: string | null): string | null {
@@ -87,6 +114,10 @@ function buildRetentionSummary(accounts: Awaited<ReturnType<RoomSnapshotStore["l
 
 export function registerRetentionSummaryRoute(app: RetentionSummaryHttpApp, store: RoomSnapshotStore | null): void {
   app.get("/ops/retention-summary", async (_request, response) => {
+    if (!requireRetentionSummaryAdminToken(_request, response)) {
+      return;
+    }
+
     if (!store) {
       sendJson(response, 503, {
         error: {

--- a/apps/server/src/infra/dev-server.ts
+++ b/apps/server/src/infra/dev-server.ts
@@ -59,6 +59,8 @@ import { createDefaultPaymentGatewayRegistry } from "@server/domain/payment/Defa
 import { captureServerError, isErrorMonitoringEnabled } from "@server/domain/ops/error-monitoring";
 import { recordRuntimeErrorEvent } from "@server/domain/ops/observability";
 import { readBattleReplayRetentionPolicy, type BattleReplayRetentionPolicy } from "@server/domain/battle/battle-replay-retention";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
+import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 
 loadEnv();
 
@@ -229,7 +231,7 @@ export interface DevServerBootstrapDependencies {
   registerSeasonRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerRuntimeObservabilityRoutes(
     app: unknown,
-    options?: { store?: DevServerRoomSnapshotStore; persistence?: RuntimePersistenceHealth }
+    options?: { store?: DevServerRoomSnapshotStore; persistence?: RuntimePersistenceHealth; enableTestRoutes?: boolean }
   ): void;
   validateBackupStorage(): Promise<BackupStorageValidationResult>;
   registerRetentionSummaryRoute(app: unknown, store: DevServerRoomSnapshotStore | null): void;
@@ -276,6 +278,35 @@ export function registerPrometheusMetricsMiddleware(app: DevServerHttpApp): void
 
 export function registerPrometheusMetricsRoute(app: DevServerHttpApp): void {
   app.get("/metrics", async (_request, response) => {
+    const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+    if (!adminToken) {
+      response.statusCode = 503;
+      response.setHeader("Content-Type", "application/json; charset=utf-8");
+      response.end(
+        JSON.stringify({
+          error: {
+            code: "admin_token_not_configured",
+            message: "VEIL_ADMIN_TOKEN is not configured"
+          }
+        })
+      );
+      return;
+    }
+
+    if (!timingSafeCompareAdminToken(_request.headers["x-veil-admin-token"], adminToken)) {
+      response.statusCode = 403;
+      response.setHeader("Content-Type", "application/json; charset=utf-8");
+      response.end(
+        JSON.stringify({
+          error: {
+            code: "forbidden",
+            message: "Invalid admin token"
+          }
+        })
+      );
+      return;
+    }
+
     response.statusCode = 200;
     response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
     response.end(`${buildPrometheusMetricsDocument()}\n`);
@@ -483,7 +514,8 @@ export async function startDevServer(
   deps.registerSeasonRoutes(expressApp, effectiveSnapshotStore);
   deps.registerRuntimeObservabilityRoutes(expressApp, {
     store: effectiveSnapshotStore,
-    persistence: persistenceHealth
+    persistence: persistenceHealth,
+    enableTestRoutes: process.env.VEIL_ENABLE_TEST_ENDPOINTS === "1"
   });
   if ("get" in (expressApp as object)) {
     deps.registerRetentionSummaryRoute(expressApp, effectiveSnapshotStore);

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -57,6 +57,12 @@ import type {
 import type { RoomPersistenceSnapshot } from "@server/index";
 import { queryEventLogEntries } from "@veil/shared/event-log";
 
+const OBSERVABILITY_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "observability-admin-token";
+process.env.VEIL_ADMIN_TOKEN = OBSERVABILITY_ADMIN_TOKEN;
+const OBSERVABILITY_ADMIN_HEADERS = {
+  "x-veil-admin-token": OBSERVABILITY_ADMIN_TOKEN
+};
+
 class MemoryAuthStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
@@ -1752,7 +1758,9 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
   assert.equal(healthPayload.runtime.auth.counters.sessionFailuresTotal, 1);
   assert.equal(healthPayload.runtime.auth.sessionFailureReasons.session_revoked, 1);
 
-  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const readinessPayload = (await readinessResponse.json()) as {
     status: string;
     headline: string;
@@ -1770,7 +1778,9 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
   assert.equal(readinessPayload.auth.activeGuestSessionCount, 1);
   assert.equal(readinessPayload.auth.activeAccountSessionCount, 1);
 
-  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const metricsText = await metricsResponse.text();
 
   assert.equal(metricsResponse.status, 200);
@@ -2217,7 +2227,9 @@ test(
   assert.equal(blockedLegitimatePayload.error.code, "credential_stuffing_blocked");
   assert.ok(blockedLegitimatePayload.error.blockedUntil);
 
-  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const readinessPayload = (await readinessResponse.json()) as {
     status: string;
     headline: string;
@@ -2236,7 +2248,9 @@ test(
   assert.equal(readinessPayload.auth.activeCredentialStuffingSourceCount, 1);
   assert.equal(readinessPayload.auth.counters.credentialStuffingBlockedTotal, 2);
 
-  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const metricsText = await metricsResponse.text();
   assert.equal(metricsResponse.status, 200);
   assert.match(metricsText, /^veil_auth_credential_stuffing_sources 1$/m);
@@ -3221,7 +3235,9 @@ test("password recovery request schedules retry for retryable webhook failures a
   assert.equal(payload.recoveryToken, undefined);
   assert.equal(webhook.requests.length, 1);
 
-  const queuedResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`);
+  const queuedResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const queuedPayload = (await queuedResponse.json()) as {
     status: string;
     delivery: {
@@ -3255,7 +3271,9 @@ test("password recovery request schedules retry for retryable webhook failures a
   assert.equal(webhook.requests.length, 2);
   assert.equal(webhook.requests[1]?.body.token, webhook.requests[0]?.body.token);
 
-  const recoveredResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`);
+  const recoveredResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const recoveredPayload = (await recoveredResponse.json()) as {
     status: string;
     delivery: {
@@ -3333,7 +3351,9 @@ test("password recovery request returns 502 and dead-letters non-retryable webho
   assert.match(payload.error.message, /400/);
   assert.equal(webhook.requests.length, 1);
 
-  const deliveryResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`);
+  const deliveryResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/account-token-delivery`, {
+    headers: OBSERVABILITY_ADMIN_HEADERS
+  });
   const deliveryPayload = (await deliveryResponse.json()) as {
     status: string;
     delivery: {

--- a/apps/server/test/http-rate-limit.test.ts
+++ b/apps/server/test/http-rate-limit.test.ts
@@ -4,6 +4,8 @@ import { __httpRateLimitInternals } from "@server/infra/http-rate-limit";
 import { startDevServer } from "@server/infra/dev-server";
 import { resetRuntimeObservability } from "@server/domain/ops/observability";
 
+const OBSERVABILITY_ADMIN_TOKEN = "http-rate-limit-admin-token";
+
 function withEnvOverrides(
   overrides: Record<string, string>,
   cleanup: Array<() => void>
@@ -34,6 +36,7 @@ test("HTTP rate limiting returns 429 with Retry-After and increments Prometheus 
   withEnvOverrides(
     {
       ADMIN_SECRET: "test-admin-secret",
+      VEIL_ADMIN_TOKEN: OBSERVABILITY_ADMIN_TOKEN,
       VEIL_TRUSTED_PROXIES: "127.0.0.1",
       VEIL_RATE_LIMIT_HTTP_WINDOW_MS: "60000",
       VEIL_RATE_LIMIT_HTTP_GLOBAL_MAX: "2",
@@ -107,7 +110,9 @@ test("HTTP rate limiting returns 429 with Retry-After and increments Prometheus 
   assert.equal(limitedGlobalResponse.headers.get("Retry-After"), "60");
 
   const metricsResponse = await fetch(`http://127.0.0.1:${port}/metrics`, {
-    headers: withHeaders(metricsIp)
+    headers: withHeaders(metricsIp, {
+      "x-veil-admin-token": OBSERVABILITY_ADMIN_TOKEN
+    })
   });
   const metricsText = await metricsResponse.text();
 

--- a/apps/server/test/http-request-context.test.ts
+++ b/apps/server/test/http-request-context.test.ts
@@ -8,6 +8,9 @@ import {
 } from "@server/infra/http-request-context";
 import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "@server/domain/ops/observability";
 
+const OBSERVABILITY_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "observability-admin-token";
+process.env.VEIL_ADMIN_TOKEN = OBSERVABILITY_ADMIN_TOKEN;
+
 interface TestLoggerEntry {
   message: string;
   error: unknown;
@@ -120,7 +123,11 @@ test("http request observability logs structured route failures and records them
   assert.equal(loggedError.errorMessage, "intentional route failure");
   assert.match(loggedError.stack ?? "", /intentional route failure/);
 
-  const diagnosticsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`);
+  const diagnosticsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`, {
+    headers: {
+      "x-veil-admin-token": OBSERVABILITY_ADMIN_TOKEN
+    }
+  });
   const diagnosticsPayload = (await diagnosticsResponse.json()) as {
     diagnostics: {
       errorEvents: Array<{

--- a/apps/server/test/retention-summary.test.ts
+++ b/apps/server/test/retention-summary.test.ts
@@ -4,6 +4,9 @@ import test from "node:test";
 import type { RoomSnapshotStore } from "@server/persistence";
 import { registerRetentionSummaryRoute } from "@server/domain/ops/retention-summary";
 
+const RETENTION_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "retention-admin-token";
+process.env.VEIL_ADMIN_TOKEN = RETENTION_ADMIN_TOKEN;
+
 test("retention summary route returns cohort metrics from account timestamps", async () => {
   const routes = new Map<string, (request: unknown, response: FakeResponse) => void | Promise<void>>();
   const app = {
@@ -37,8 +40,18 @@ test("retention summary route returns cohort metrics from account timestamps", a
   } as Pick<RoomSnapshotStore, "listPlayerAccounts"> as RoomSnapshotStore;
 
   registerRetentionSummaryRoute(app as never, store);
+
+  const unauthorizedResponse = new FakeResponse();
+  await routes.get("/ops/retention-summary")?.({ headers: {} } as never, unauthorizedResponse);
+  assert.equal(unauthorizedResponse.statusCode, 403);
+  const unauthorizedPayload = JSON.parse(unauthorizedResponse.body);
+  assert.equal(unauthorizedPayload.error.code, "forbidden");
+
   const response = new FakeResponse();
-  await routes.get("/ops/retention-summary")?.({} as never, response);
+  await routes.get("/ops/retention-summary")?.(
+    { headers: { "x-veil-admin-token": RETENTION_ADMIN_TOKEN } } as never,
+    response
+  );
 
   assert.equal(response.statusCode, 200);
   const payload = JSON.parse(response.body);

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -16,6 +16,9 @@ import {
   resetRuntimeObservability
 } from "@server/domain/ops/observability";
 
+const RUNTIME_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "runtime-admin-token";
+process.env.VEIL_ADMIN_TOKEN = RUNTIME_ADMIN_TOKEN;
+
 async function wait(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -173,6 +176,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   process.env.ANALYTICS_DELETION_WORKFLOW = "dsr-player-delete";
   const server = await startObservabilityServer(port);
   const room = await joinRoom(port, "room-observability-alpha", "player-1");
+  const adminHeaders = {
+    "x-veil-admin-token": RUNTIME_ADMIN_TOKEN
+  };
 
   t.after(async () => {
     if (originalFeatureFlagJson === undefined) {
@@ -328,18 +334,31 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPayload.runtime.antiCheat.counters.alertsTotal, 0);
   assert.equal(healthPayload.runtime.antiCheat.alertsTracked, 0);
 
-  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const unauthorizedReadinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const unauthorizedReadinessPayload = (await unauthorizedReadinessResponse.json()) as {
+    error?: {
+      code?: string;
+    };
+  };
+  assert.equal(unauthorizedReadinessResponse.status, 403);
+  assert.equal(unauthorizedReadinessPayload.error?.code, "forbidden");
+
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`, {
+    headers: adminHeaders
+  });
   const readinessPayload = (await readinessResponse.json()) as {
     status: string;
     headline: string;
   };
 
   assert.equal(readinessResponse.status, 200);
-  assert.equal(readinessResponse.headers.get("access-control-allow-origin"), "*");
+  assert.equal(readinessResponse.headers.get("access-control-allow-origin"), null);
   assert.equal(readinessPayload.status, "ok");
   assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
 
-  const featureFlagResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/feature-flags`);
+  const featureFlagResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/feature-flags`, {
+    headers: adminHeaders
+  });
   const featureFlagPayload = (await featureFlagResponse.json()) as {
     status: string;
     headline: string;
@@ -370,7 +389,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(featureFlagPayload.flags.find((flag) => flag.flagKey === "battle_pass_enabled")?.stages[0]?.key, "canary-1");
   assert.equal(featureFlagPayload.auditHistory[0]?.ticket, "#1203");
 
-  const killSwitchResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/kill-switches`);
+  const killSwitchResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/kill-switches`, {
+    headers: adminHeaders
+  });
   const killSwitchPayload = (await killSwitchResponse.json()) as {
     status: string;
     headline: string;
@@ -396,7 +417,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(killSwitchPayload.killSwitches.find((entry) => entry.key === "wechat_matchmaking")?.channels?.[0], "wechat");
   assert.match(killSwitchPayload.headline, /kill_switches active=0/);
 
-  const diagnosticResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`);
+  const diagnosticResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`, {
+    headers: adminHeaders
+  });
   const diagnosticPayload = (await diagnosticResponse.json()) as {
     source: {
       surface: string;
@@ -441,7 +464,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(diagnosticPayload.diagnostics.errorSummary.topFingerprints[0]?.featureArea, "payment");
   assert.match(diagnosticPayload.diagnostics.logTail[0] ?? "", /rooms=1 connections=1/);
 
-  const diagnosticTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot?format=text`);
+  const diagnosticTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot?format=text`, {
+    headers: adminHeaders
+  });
   const diagnosticText = await diagnosticTextResponse.text();
 
   assert.equal(diagnosticTextResponse.status, 200);
@@ -452,7 +477,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(diagnosticText, /Errors 1 \/ fingerprints 1 \/ fatal 0 \/ crashes 0/);
   assert.match(diagnosticText, /Room summary room-observability-alpha \/ day 1 \/ players 1/);
 
-  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`, {
+    headers: adminHeaders
+  });
   const metricsText = await metricsResponse.text();
 
   assert.equal(metricsResponse.status, 200);
@@ -484,7 +511,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
     /^veil_runtime_error_events_total\{error_code="wechat_pay_timeout",feature_area="payment",owner_area="commerce",severity="error"\} 1$/m
   );
 
-  const roomLifecycleResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary`);
+  const roomLifecycleResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary`, {
+    headers: adminHeaders
+  });
   const roomLifecyclePayload = (await roomLifecycleResponse.json()) as {
     status: string;
     headline: string;
@@ -517,9 +546,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(roomLifecyclePayload.summary.recentEvents[0]?.kind, "room.created");
   assert.equal(roomLifecyclePayload.summary.recentEvents[0]?.roomId, "room-observability-alpha");
 
-  const roomLifecycleTextResponse = await fetch(
-    `http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary?format=text`
-  );
+  const roomLifecycleTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary?format=text`, {
+    headers: adminHeaders
+  });
   const roomLifecycleText = await roomLifecycleTextResponse.text();
 
   assert.equal(roomLifecycleTextResponse.status, 200);
@@ -529,7 +558,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(roomLifecycleText, /room_creates=1/);
   assert.match(roomLifecycleText, /room\.created/);
 
-  const analyticsPipelineResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/analytics-pipeline`);
+  const analyticsPipelineResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/analytics-pipeline`, {
+    headers: adminHeaders
+  });
   const analyticsPipelinePayload = (await analyticsPipelineResponse.json()) as {
     status: string;
     sink: string;
@@ -562,7 +593,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
     1
   );
 
-  const analyticsPipelineTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/analytics-pipeline?format=text`);
+  const analyticsPipelineTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/analytics-pipeline?format=text`, {
+    headers: adminHeaders
+  });
   const analyticsPipelineText = await analyticsPipelineTextResponse.text();
 
   assert.equal(analyticsPipelineTextResponse.status, 200);
@@ -578,7 +611,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPreflightResponse.status, 204);
   assert.equal(healthPreflightResponse.headers.get("access-control-allow-origin"), "*");
 
-  const prometheusResponse = await fetch(`http://127.0.0.1:${port}/metrics`);
+  const prometheusResponse = await fetch(`http://127.0.0.1:${port}/metrics`, {
+    headers: adminHeaders
+  });
   const prometheusText = await prometheusResponse.text();
 
   assert.equal(prometheusResponse.status, 200);

--- a/apps/server/test/ws-action-rate-limit.test.ts
+++ b/apps/server/test/ws-action-rate-limit.test.ts
@@ -7,6 +7,9 @@ import { configureRoomSnapshotStore, resetLobbyRoomRegistry, VeilColyseusRoom } 
 import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "@server/domain/ops/observability";
 import { resetAccountTokenDeliveryState } from "@server/adapters/account-token-delivery";
 
+const OBSERVABILITY_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "observability-admin-token";
+process.env.VEIL_ADMIN_TOKEN = OBSERVABILITY_ADMIN_TOKEN;
+
 interface FakeClient {
   sessionId: string;
   state: number;
@@ -357,7 +360,11 @@ test("observability reports websocket action rate-limit violations and kicks", {
           };
         };
       };
-      const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+      const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`, {
+        headers: {
+          "x-veil-admin-token": OBSERVABILITY_ADMIN_TOKEN
+        }
+      });
       const metricsText = await metricsResponse.text();
 
       assert.equal(healthResponse.status, 200);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -89,12 +89,15 @@ const clientOrigin = normalizeOrigin(process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN, 
 const runId = process.env.VEIL_PLAYWRIGHT_RUN_ID?.trim() || `${path.basename(process.cwd())}-${process.pid}`;
 const playwrightOutputDir = process.env.PLAYWRIGHT_OUTPUT_DIR?.trim() || path.join("test-results", runId);
 const playwrightReportDir = process.env.PLAYWRIGHT_HTML_REPORT?.trim() || path.join("playwright-report", runId);
+const adminToken = process.env.VEIL_ADMIN_TOKEN?.trim() || "dev-admin-token";
 
 process.env.VEIL_PLAYWRIGHT_SERVER_PORT = String(serverPort);
 process.env.VEIL_PLAYWRIGHT_CLIENT_PORT = String(clientPort);
 process.env.VEIL_PLAYWRIGHT_SERVER_ORIGIN = serverOrigin;
 process.env.VEIL_PLAYWRIGHT_SERVER_WS_URL = serverWsOrigin;
 process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN = clientOrigin;
+process.env.VEIL_ADMIN_TOKEN = adminToken;
+process.env.VEIL_ENABLE_TEST_ENDPOINTS = process.env.VEIL_ENABLE_TEST_ENDPOINTS?.trim() || "1";
 
 const SMOKE_PROJECT_NAME = "smoke";
 const H5_CONNECTIVITY_PROJECT_NAME = "h5-connectivity";
@@ -175,7 +178,8 @@ function createSharedWebServers(): WebServerPlugin[] {
         PORT: String(serverPort),
         ANALYTICS_ENDPOINT: `${serverOrigin}/api/test/analytics/events`,
         ANALYTICS_SINK: "http",
-        VEIL_ADMIN_TOKEN: process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token",
+        VEIL_ADMIN_TOKEN: adminToken,
+        VEIL_ENABLE_TEST_ENDPOINTS: "1",
         VEIL_DAILY_QUESTS_ENABLED: "1",
         VEIL_DAILY_QUEST_ROTATIONS_JSON: DAILY_QUEST_SMOKE_ROTATIONS,
         VEIL_RATE_LIMIT_AUTH_MAX: process.env.VEIL_RATE_LIMIT_AUTH_MAX ?? "120",
@@ -223,6 +227,9 @@ export default defineConfig({
   reporter: SHARED_REPORTER,
   use: {
     baseURL: clientOrigin,
+    extraHTTPHeaders: {
+      "x-veil-admin-token": adminToken
+    },
     headless: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",

--- a/scripts/client-boot-room-smoke.ts
+++ b/scripts/client-boot-room-smoke.ts
@@ -13,6 +13,7 @@ const DEFAULT_SERVER_WS_URL = "ws://127.0.0.1:2567";
 const STARTUP_TIMEOUT_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const LOG_TAIL_LIMIT = 80;
+const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "dev-admin-token";
 
 interface SmokeRuntimeTargets {
   serverUrl: string;
@@ -126,8 +127,8 @@ async function fetchText(url: string): Promise<string> {
   return await response.text();
 }
 
-async function fetchJson<T>(url: string): Promise<HttpJsonResponse<T>> {
-  const response = await fetch(url);
+async function fetchJson<T>(url: string, headers?: Record<string, string>): Promise<HttpJsonResponse<T>> {
+  const response = await fetch(url, headers ? { headers } : undefined);
   if (!response.ok) {
     throw new Error(`GET ${url} returned HTTP ${response.status}`);
   }
@@ -184,7 +185,9 @@ async function verifyClientBoot(): Promise<void> {
 
   await fetchRuntimeHealth(`${CLIENT_URL}/api/runtime/health`, "client-proxied runtime health");
 
-  const authReadiness = await fetchJson<RuntimeStatusPayload>(`${CLIENT_URL}/api/runtime/auth-readiness`);
+  const authReadiness = await fetchJson<RuntimeStatusPayload>(`${CLIENT_URL}/api/runtime/auth-readiness`, {
+    "x-veil-admin-token": ADMIN_TOKEN
+  });
   if (authReadiness.body.status !== "ok") {
     throw new Error(`client-proxied auth readiness is ${JSON.stringify(authReadiness.body)}`);
   }
@@ -204,7 +207,9 @@ async function waitForServerReadiness(): Promise<void> {
     STARTUP_TIMEOUT_MS
   );
 
-  const authReadiness = await fetchJson<RuntimeStatusPayload>(`${SERVER_URL}/api/runtime/auth-readiness`);
+  const authReadiness = await fetchJson<RuntimeStatusPayload>(`${SERVER_URL}/api/runtime/auth-readiness`, {
+    "x-veil-admin-token": ADMIN_TOKEN
+  });
   if (authReadiness.body.status !== "ok") {
     throw new Error(`runtime auth-readiness is ${JSON.stringify(authReadiness.body)}`);
   }

--- a/scripts/validate-local-dev-quickstart.mjs
+++ b/scripts/validate-local-dev-quickstart.mjs
@@ -11,6 +11,7 @@ export const QUICKSTART_H5_BUILD_SCRIPT = "build:client:h5";
 export const QUICKSTART_H5_DEV_SCRIPT = "dev:client:h5";
 export const QUICKSTART_SERVER_URL = "http://127.0.0.1:2567";
 export const QUICKSTART_HEALTH_CHECKS = ["/api/runtime/health", "/api/runtime/auth-readiness", "/api/lobby/rooms"];
+const QUICKSTART_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "dev-admin-token";
 const startupTimeoutMs = 20_000;
 
 function logStep(message) {
@@ -63,7 +64,14 @@ async function waitForServer() {
 
 async function verifyEndpoints() {
   for (const path of QUICKSTART_HEALTH_CHECKS) {
-    const response = await fetch(`${QUICKSTART_SERVER_URL}${path}`);
+    const response = await fetch(`${QUICKSTART_SERVER_URL}${path}`, {
+      headers:
+        path === "/api/runtime/auth-readiness"
+          ? {
+              "x-veil-admin-token": QUICKSTART_ADMIN_TOKEN
+            }
+          : undefined
+    });
     if (path === "/api/runtime/health") {
       const payload = await response.json();
       assertBaselineRuntimeHealthResponse(response.status, payload, "runtime health");
@@ -91,6 +99,7 @@ export async function main() {
 
   logStep("starting the dev server without MySQL env overrides");
   const envWithoutMySql = { ...process.env };
+  envWithoutMySql.VEIL_ADMIN_TOKEN = envWithoutMySql.VEIL_ADMIN_TOKEN?.trim() || QUICKSTART_ADMIN_TOKEN;
   for (const key of Object.keys(envWithoutMySql)) {
     if (key.startsWith("VEIL_MYSQL_")) {
       delete envWithoutMySql[key];

--- a/tests/e2e/battle-pass-progression.spec.ts
+++ b/tests/e2e/battle-pass-progression.spec.ts
@@ -6,7 +6,7 @@ import {
   type PlayerWorldView,
   type SessionStatePayload
 } from "../../packages/shared/src/index";
-import { SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
 const BATTLE_PASS_TIER = 2;
 const BATTLE_PASS_TIER_XP_REQUIRED = 500;
 const BATTLE_PASS_TIER_REWARD = {
@@ -237,7 +237,11 @@ async function fetchGoldBalance(
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/battle-replay-smoke.spec.ts
+++ b/tests/e2e/battle-replay-smoke.spec.ts
@@ -8,7 +8,7 @@ import {
   resolveBattleToSettlement,
   withSmokeDiagnostics
 } from "./smoke-helpers";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 
 interface PlayerBattleReplaySummary {
   id: string;
@@ -65,7 +65,11 @@ test("battle replay center smoke persists a resolved PvP battle and supports acc
   browser,
   request
 }, testInfo) => {
-  const resetResponse = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const resetResponse = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(resetResponse.ok()).toBeTruthy();
 
   const roomId = buildRoomId("e2e-battle-replay");

--- a/tests/e2e/campaign-mission-flow.spec.ts
+++ b/tests/e2e/campaign-mission-flow.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
 import { pollForAnalyticsEvent } from "./analytics-helpers";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 const FIRST_MISSION_ID = "chapter1-ember-watch";
 const FIRST_MISSION_MAP_ID = "amber-fields";
 const FIRST_CHAPTER_ID = "chapter1";
@@ -131,7 +131,11 @@ async function completeMission(request: APIRequestContext, token: string, missio
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/daily-dungeon.spec.ts
+++ b/tests/e2e/daily-dungeon.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 const ACTIVE_WINDOW_NOW = "2026-04-10T12:00:00.000Z";
 const INACTIVE_WINDOW_NOW = "2026-05-12T12:00:00.000Z";
 const ACTIVE_DUNGEON_ID = "shadow-archives";
@@ -75,7 +75,11 @@ async function createGuestSessionToken(request: APIRequestContext, playerId: str
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base } from "@playwright/test";
-import { CLIENT_BASE_URL, RESET_ENDPOINT } from "./runtime-targets";
+import { ADMIN_TOKEN, CLIENT_BASE_URL, RESET_ENDPOINT } from "./runtime-targets";
 
 /**
  * Custom test fixture that automatically resets the server's in-memory store
@@ -18,11 +18,19 @@ export const test = base.extend({
   page: async ({ page }, use) => {
     // Reset the server's in-memory store before each test
     try {
-      let response = await page.context().request.post(RESET_ENDPOINT);
+      let response = await page.context().request.post(RESET_ENDPOINT, {
+        headers: {
+          "x-veil-admin-token": ADMIN_TOKEN
+        }
+      });
       for (let attempt = 0; attempt < 4 && response.status() === 429; attempt += 1) {
         const retryAfterSeconds = Math.max(1, Number(response.headers()["retry-after"] ?? "1"));
         await new Promise((resolve) => setTimeout(resolve, retryAfterSeconds * 1000));
-        response = await page.context().request.post(RESET_ENDPOINT);
+        response = await page.context().request.post(RESET_ENDPOINT, {
+          headers: {
+            "x-veil-admin-token": ADMIN_TOKEN
+          }
+        });
       }
       if (!response.ok()) {
         console.warn(`Store reset failed: ${response.status()}`);

--- a/tests/e2e/guild-lifecycle.spec.ts
+++ b/tests/e2e/guild-lifecycle.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {
@@ -58,7 +58,11 @@ async function createGuestSessionToken(
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/leaderboard-ranked-season.spec.ts
+++ b/tests/e2e/leaderboard-ranked-season.spec.ts
@@ -12,7 +12,7 @@ import {
   resolveBattleToSettlement,
   startDeterministicPvpBattle
 } from "./smoke-helpers";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {
@@ -56,7 +56,10 @@ interface LeaderboardPayload {
 
 async function resetStore(): Promise<void> {
   const response = await fetch(`${SERVER_BASE_URL}/api/test/reset-store`, {
-    method: "POST"
+    method: "POST",
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
   });
   if (!response.ok) {
     throw new Error(`reset_store_failed:${response.status}`);

--- a/tests/e2e/multiplayer-stress.spec.ts
+++ b/tests/e2e/multiplayer-stress.spec.ts
@@ -10,7 +10,7 @@ import {
   reloadAndExpectAuthoritativeConvergence,
   withSmokeDiagnostics
 } from "./smoke-helpers";
-import { SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL, SERVER_WS_URL } from "./runtime-targets";
 
 interface AutomationState {
   hero?: {
@@ -56,7 +56,11 @@ interface RawSession {
 }
 
 async function resetStore(request: APIRequestContext): Promise<void> {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 }
 

--- a/tests/e2e/player-mailbox.spec.ts
+++ b/tests/e2e/player-mailbox.spec.ts
@@ -129,7 +129,11 @@ async function deliverMailboxMessage(
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/pvp-matchmaking-lifecycle.spec.ts
+++ b/tests/e2e/pvp-matchmaking-lifecycle.spec.ts
@@ -7,7 +7,7 @@ import {
   resolveBattleToSettlement,
   startDeterministicPvpBattle
 } from "./smoke-helpers";
-import { SERVER_BASE_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 
 interface GuestLoginPayload {
   session?: {
@@ -35,7 +35,10 @@ interface PlayerBattleReplayListPayload {
 
 async function resetStore(): Promise<void> {
   const response = await fetch(`${SERVER_BASE_URL}/api/test/reset-store`, {
-    method: "POST"
+    method: "POST",
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
   });
   if (!response.ok) {
     throw new Error(`reset_store_failed:${response.status}`);

--- a/tests/e2e/runtime-targets.ts
+++ b/tests/e2e/runtime-targets.ts
@@ -19,6 +19,7 @@ export const SERVER_WS_URL =
   process.env.VEIL_PLAYWRIGHT_SERVER_WS_URL?.trim() || `ws://${SERVER_HOST}:${SERVER_PORT}`;
 export const CLIENT_BASE_URL =
   process.env.VEIL_PLAYWRIGHT_CLIENT_ORIGIN?.trim() || `http://${CLIENT_HOST}:${CLIENT_PORT}`;
+export const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "dev-admin-token";
 export const ADMIN_BASE_URL = `${SERVER_BASE_URL}/admin`;
 export const ANALYTICS_CAPTURE_ENDPOINT = `${SERVER_BASE_URL}/api/test/analytics/events`;
 export const RESET_ENDPOINT = `${SERVER_BASE_URL}/api/test/reset-store`;

--- a/tests/e2e/seasonal-event-lifecycle.spec.ts
+++ b/tests/e2e/seasonal-event-lifecycle.spec.ts
@@ -160,7 +160,11 @@ async function fetchProfile(
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/shop-purchase-settlement.spec.ts
+++ b/tests/e2e/shop-purchase-settlement.spec.ts
@@ -124,7 +124,11 @@ async function fetchProfile(request: APIRequestContext, authHeaders: Record<stri
 }
 
 test.beforeEach(async ({ request }) => {
-  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    }
+  });
   expect(response.ok()).toBeTruthy();
 });
 

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page, type TestInfo } from "@playwright/test";
 import { getHeroMoveTotal } from "./config-fixtures";
-import { CLIENT_BASE_URL, RESET_ENDPOINT, SERVER_DIAGNOSTICS_URL } from "./runtime-targets";
+import { ADMIN_TOKEN, CLIENT_BASE_URL, RESET_ENDPOINT, SERVER_DIAGNOSTICS_URL } from "./runtime-targets";
 
 interface RoomSessionOptions {
   roomId: string;
@@ -71,10 +71,22 @@ export function moveRemainingAfterSpend(spent: number, playerId = "player-1"): n
   return getHeroMoveTotal(playerId) - spent;
 }
 
-async function fetchJsonFromBrowser<T>(page: Page, path: string): Promise<T> {
-  return await page.evaluate(async (requestPath) => {
+function getAdminHeaders(): Record<string, string> {
+  return {
+    "x-veil-admin-token": ADMIN_TOKEN
+  };
+}
+
+async function fetchJsonFromBrowser<T>(
+  page: Page,
+  path: string,
+  headers: Record<string, string> = getAdminHeaders()
+): Promise<T> {
+  return await page.evaluate(async ({ requestPath, requestHeaders }) => {
     for (let attempt = 0; attempt < 5; attempt += 1) {
-      const response = await fetch(requestPath);
+      const response = await fetch(requestPath, {
+        headers: requestHeaders
+      });
       if (response.ok) {
         return (await response.json()) as T;
       }
@@ -85,8 +97,8 @@ async function fetchJsonFromBrowser<T>(page: Page, path: string): Promise<T> {
       }
       throw new Error(`browser_fetch_failed:${requestPath}:${response.status}`);
     }
-    throw new Error(`browser_fetch_failed:${requestPath}:unreachable`);
-  }, path);
+      throw new Error(`browser_fetch_failed:${requestPath}:unreachable`);
+  }, { requestPath: path, requestHeaders: headers });
 }
 
 export async function waitForLobbyReady(page: Page): Promise<void> {
@@ -94,10 +106,13 @@ export async function waitForLobbyReady(page: Page): Promise<void> {
     // Reset the server's in-memory store before entering lobby
     // The fixture also resets server-side, but this ensures the browser
     // context is fresh after being reused across tests
-    await page.evaluate(async () => {
+    await page.evaluate(async (adminToken) => {
+      const adminHeaders = {
+        "x-veil-admin-token": adminToken
+      };
       for (let attempt = 0; attempt < 5; attempt += 1) {
         try {
-          const response = await fetch("/api/test/reset-store", { method: "POST" });
+          const response = await fetch("/api/test/reset-store", { method: "POST", headers: adminHeaders });
           if (response.ok || response.status !== 429 || attempt === 4) {
             return;
           }
@@ -108,11 +123,11 @@ export async function waitForLobbyReady(page: Page): Promise<void> {
         }
       }
       try {
-        await fetch("/api/test/reset-store", { method: "POST" });
+        await fetch("/api/test/reset-store", { method: "POST", headers: adminHeaders });
       } catch {
         // Ignore errors if endpoint not available
       }
-    });
+    }, ADMIN_TOKEN);
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
@@ -505,7 +520,9 @@ async function attachPageDiagnostics(testInfo: TestInfo, page: Page, label: stri
 
 async function attachServerDiagnostics(testInfo: TestInfo): Promise<void> {
   try {
-    const response = await fetch(SERVER_DIAGNOSTICS_URL);
+    const response = await fetch(SERVER_DIAGNOSTICS_URL, {
+      headers: getAdminHeaders()
+    });
     if (!response.ok) {
       await attachText(testInfo, "server-diagnostics-error.txt", `HTTP ${response.status}`);
       return;


### PR DESCRIPTION
Closes #1664. Closes #1667.\n\n- Protect runtime observability, metrics, retention, and reset-store surfaces with admin-token checks.\n- Keep runtime health public.\n- Update smoke/e2e helpers to send explicit admin tokens where protected test hooks are used.\n\nVerification:\n- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/server/test/runtime-observability-routes.test.ts apps/server/test/retention-summary.test.ts apps/server/test/http-request-context.test.ts apps/server/test/ws-action-rate-limit.test.ts scripts/test/client-boot-room-smoke.test.ts