### PR TITLE
Restrict MySQL egress network policy

### DIFF
--- a/k8s/canary/network-policy.yaml
+++ b/k8s/canary/network-policy.yaml
@@ -39,9 +39,13 @@ spec:
           port: 6379
     - to:
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: 10.0.0.0/16
       ports:
         - protocol: TCP
           port: 3306
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: TCP
           port: 443

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -39,9 +39,13 @@ spec:
           port: 6379
     - to:
         - ipBlock:
-            cidr: 0.0.0.0/0
+            cidr: 10.0.0.0/16
       ports:
         - protocol: TCP
           port: 3306
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
         - protocol: TCP
           port: 443

--- a/scripts/test/k8s-runtime-hardening.test.ts
+++ b/scripts/test/k8s-runtime-hardening.test.ts
@@ -81,7 +81,9 @@ test("network policy restricts ingress to ingress-nginx and narrows egress", asy
     assert.match(policy, /port:\s*2567/);
     assert.match(policy, /kubernetes\.io\/metadata\.name:\s*kube-system/);
     assert.match(policy, /port:\s*6379/);
+    assert.match(policy, /cidr:\s*10\.0\.0\.0\/16\s*\n\s*ports:\s*\n\s*-\s*protocol:\s*TCP\s*\n\s*port:\s*3306/);
     assert.match(policy, /port:\s*3306/);
+    assert.doesNotMatch(policy, /cidr:\s*0\.0\.0\.0\/0\s*\n\s*ports:\s*\n\s*-\s*protocol:\s*TCP\s*\n\s*port:\s*3306/);
     assert.match(policy, /port:\s*443/);
   }
 });


### PR DESCRIPTION
Closes #1671.\n\n- Narrow MySQL egress to the private VPC CIDR.\n- Keep HTTPS egress separately allowed.\n- Update runtime hardening tests for the split egress policy.\n\nVerification:\n- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test scripts/test/k8s-runtime-hardening.test.ts