### PR TITLE
Harden player progression action guards

### DIFF
--- a/apps/server/src/domain/account/player-accounts.ts
+++ b/apps/server/src/domain/account/player-accounts.ts
@@ -31,10 +31,12 @@ import type {
   SupportTicketPriority
 } from "@server/persistence";
 import {
+  consumeActionSubmissionRateLimit,
   applySeasonalEventProgress,
   buildEventLeaderboard,
   findSeasonalEventState,
   getActiveSeasonalEvents,
+  isActionSubmissionRateLimitEnabled,
   resolveSeasonalEvents
 } from "@server/domain/battle/event-engine";
 import { resolveFeatureEntitlementsForPlayer, resolveFeatureFlagsForPlayer } from "@server/domain/battle/feature-flags";
@@ -233,7 +235,18 @@ function parseOffset(request: IncomingMessage): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function isTestTimeOverrideEnabled(): boolean {
+  return (
+    process.env.NODE_ENV?.trim().toLowerCase() !== "production" ||
+    process.env.VEIL_ENABLE_TEST_TIME_OVERRIDE?.trim() === "1"
+  );
+}
+
 function readDailyDungeonNowOverride(request: IncomingMessage): Date | null {
+  if (!isTestTimeOverrideEnabled()) {
+    return null;
+  }
+
   const rawValue = request.headers["x-veil-test-now"];
   const value = Array.isArray(rawValue) ? rawValue[0] : rawValue;
   const trimmed = value?.trim();
@@ -247,6 +260,33 @@ function readDailyDungeonNowOverride(request: IncomingMessage): Date | null {
 
 function resolveDailyDungeonNow(request: IncomingMessage): Date {
   return readDailyDungeonNowOverride(request) ?? new Date();
+}
+
+export const __playerAccountRouteInternals = {
+  hasVerifiedCampaignMissionCompletion,
+  isTestTimeOverrideEnabled,
+  readDailyDungeonNowOverride,
+  resolveDailyDungeonNow
+} as const;
+
+function hasVerifiedCampaignMissionCompletion(account: PlayerAccountSnapshot, mission: { mapId: string }): boolean {
+  return (
+    account.recentBattleReplays?.some(
+      (replay) => replay.roomId === mission.mapId && replay.result === "attacker_victory"
+    ) ?? false
+  );
+}
+
+function sendActionSubmissionRateLimited(response: ServerResponse, retryAfterSeconds?: number): void {
+  if (retryAfterSeconds != null) {
+    response.setHeader("Retry-After", String(retryAfterSeconds));
+  }
+  sendJson(response, 429, {
+    error: {
+      code: "rate_limited",
+      message: "Too many requests, please retry later"
+    }
+  });
 }
 
 function parsePlayerIdFilter(request: IncomingMessage): string | undefined {
@@ -2232,6 +2272,14 @@ export function registerPlayerAccountRoutes(
       return;
     }
 
+    if (isActionSubmissionRateLimitEnabled()) {
+      const rateLimitResult = consumeActionSubmissionRateLimit(`campaign-mission-complete:${authSession.playerId}`);
+      if (!rateLimitResult.allowed) {
+        sendActionSubmissionRateLimited(response, rateLimitResult.retryAfterSeconds);
+        return;
+      }
+    }
+
     try {
       const account =
         (await store.loadPlayerAccount(authSession.playerId)) ??
@@ -2239,7 +2287,45 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      const result = completeCampaignMission(resolveCampaignConfig(), account.campaignProgress, missionId);
+      const missions = resolveCampaignConfig();
+      const mission = buildCampaignMissionStates(missions, account.campaignProgress).find((entry) => entry.id === missionId);
+      if (!mission) {
+        sendJson(response, 404, {
+          error: {
+            code: "campaign_mission_not_found",
+            message: "Campaign mission was not found"
+          }
+        });
+        return;
+      }
+      if (mission.status === "locked") {
+        sendJson(response, 409, {
+          error: {
+            code: "campaign_mission_locked",
+            message: "Campaign mission is not unlocked yet"
+          }
+        });
+        return;
+      }
+      if (mission.status === "completed") {
+        sendJson(response, 409, {
+          error: {
+            code: "campaign_mission_already_completed",
+            message: "Campaign mission has already been completed"
+          }
+        });
+        return;
+      }
+      if (!hasVerifiedCampaignMissionCompletion(account, mission)) {
+        sendJson(response, 403, {
+          error: {
+            code: "campaign_mission_action_not_verified",
+            message: "Campaign mission completion must follow a verified victory replay"
+          }
+        });
+        return;
+      }
+      const result = completeCampaignMission(missions, account.campaignProgress, missionId);
       const rewardMutation = toRewardMutation(account, result.reward);
       const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
         campaignProgress: result.campaignProgress,
@@ -2346,6 +2432,14 @@ export function registerPlayerAccountRoutes(
         }
       });
       return;
+    }
+
+    if (isActionSubmissionRateLimitEnabled()) {
+      const rateLimitResult = consumeActionSubmissionRateLimit(`daily-dungeon-attempt:${authSession.playerId}`);
+      if (!rateLimitResult.allowed) {
+        sendActionSubmissionRateLimited(response, rateLimitResult.retryAfterSeconds);
+        return;
+      }
     }
 
     try {
@@ -3181,6 +3275,10 @@ export function registerPlayerAccountRoutes(
       sendNotFound(response);
       return;
     }
+    const authorizedPlayerScope = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authorizedPlayerScope) {
+      return;
+    }
 
     if (!store) {
       sendJson(response, 200, {
@@ -3217,6 +3315,10 @@ export function registerPlayerAccountRoutes(
     const playerId = request.params.playerId?.trim();
     if (!playerId) {
       sendNotFound(response);
+      return;
+    }
+    const authorizedPlayerScope = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authorizedPlayerScope) {
       return;
     }
 

--- a/apps/server/src/domain/battle/event-engine.ts
+++ b/apps/server/src/domain/battle/event-engine.ts
@@ -103,8 +103,59 @@ const DAILY_QUEST_TIER_WEIGHTS: Record<DailyQuestConfigDefinition["tier"], numbe
   rare: 0.3,
   epic: 0.1
 };
+const ACTION_SUBMISSION_RATE_LIMIT_WINDOW_MS = 5_000;
+const ACTION_SUBMISSION_RATE_LIMIT_MAX = 1;
 const seasonalEventRuntimeOverrides = new Map<string, SeasonalEventRuntimeOverride>();
 const seasonalEventOpsAuditTrail: SeasonalEventOpsAuditEntry[] = [];
+const actionSubmissionRateLimitHits = new Map<string, number[]>();
+
+export function isActionSubmissionRateLimitEnabled(): boolean {
+  return (
+    process.env.NODE_ENV?.trim().toLowerCase() === "production" &&
+    process.env.VEIL_DISABLE_ACTION_SUBMISSION_RATE_LIMIT?.trim() !== "1"
+  );
+}
+
+export function resetActionSubmissionRateLimitState(): void {
+  actionSubmissionRateLimitHits.clear();
+}
+
+export function consumeActionSubmissionRateLimit(
+  key: string,
+  nowMs = Date.now()
+): { allowed: boolean; retryAfterSeconds?: number } {
+  const windowStart = nowMs - ACTION_SUBMISSION_RATE_LIMIT_WINDOW_MS;
+  const timestamps = (actionSubmissionRateLimitHits.get(key) ?? []).filter((timestamp) => timestamp > windowStart);
+  if (timestamps.length >= ACTION_SUBMISSION_RATE_LIMIT_MAX) {
+    const oldestTimestamp = timestamps[0] ?? nowMs;
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((oldestTimestamp + ACTION_SUBMISSION_RATE_LIMIT_WINDOW_MS - nowMs) / 1000))
+    };
+  }
+
+  timestamps.push(nowMs);
+  actionSubmissionRateLimitHits.set(key, timestamps);
+  return { allowed: true };
+}
+
+export function hasVerifiedDailyDungeonClaim(
+  account: Pick<PlayerAccountSnapshot, "dailyDungeonState">,
+  actionId: string,
+  dungeonId: string
+): boolean {
+  const normalizedActionId = actionId.trim();
+  const normalizedDungeonId = dungeonId.trim();
+  if (!normalizedActionId || !normalizedDungeonId) {
+    return false;
+  }
+
+  return (
+    account.dailyDungeonState?.runs.some(
+      (run) => run.runId === normalizedActionId && run.dungeonId === normalizedDungeonId && run.rewardClaimedAt != null
+    ) ?? false
+  );
+}
 
 function isValidDateKey(value: string): boolean {
   return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00.000Z`));
@@ -1163,6 +1214,22 @@ export function registerEventRoutes(
       return;
     }
 
+    if (isActionSubmissionRateLimitEnabled()) {
+      const rateLimitResult = consumeActionSubmissionRateLimit(`seasonal-event-progress:${authSession.playerId}`);
+      if (!rateLimitResult.allowed) {
+        if (rateLimitResult.retryAfterSeconds != null) {
+          response.setHeader("Retry-After", String(rateLimitResult.retryAfterSeconds));
+        }
+        sendJson(response, 429, {
+          error: {
+            code: "rate_limited",
+            message: "Too many requests, please retry later"
+          }
+        });
+        return;
+      }
+    }
+
     if (!store) {
       sendJson(response, 503, {
         error: {
@@ -1223,6 +1290,20 @@ export function registerEventRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
+      if (actionType === "daily_dungeon_reward_claimed") {
+        const expectedDungeonId = event.objectives.find(
+          (objective) => objective.actionType === actionType && objective.dungeonId
+        )?.dungeonId;
+        if (!expectedDungeonId || !hasVerifiedDailyDungeonClaim(account, actionId, expectedDungeonId)) {
+          sendJson(response, 403, {
+            error: {
+              code: "seasonal_event_action_not_verified",
+              message: "Seasonal event progress must reference a claimed daily dungeon run"
+            }
+          });
+          return;
+        }
+      }
       const progress = applySeasonalEventProgress(
         event,
         findSeasonalEventState(account.seasonalEventStates, event.id),

--- a/apps/server/test/action-guard-helpers.test.ts
+++ b/apps/server/test/action-guard-helpers.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import type { IncomingMessage } from "node:http";
+import test from "node:test";
+import {
+  consumeActionSubmissionRateLimit,
+  hasVerifiedDailyDungeonClaim,
+  resetActionSubmissionRateLimitState
+} from "@server/domain/battle/event-engine";
+import { __playerAccountRouteInternals } from "@server/domain/account/player-accounts";
+import type { PlayerAccountSnapshot } from "@server/persistence";
+
+function createRequestWithTestNow(value: string): IncomingMessage {
+  return {
+    headers: {
+      "x-veil-test-now": value
+    }
+  } as unknown as IncomingMessage;
+}
+
+test("daily dungeon test-now override is only honored in test mode", () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverride = process.env.VEIL_ENABLE_TEST_TIME_OVERRIDE;
+
+  try {
+    process.env.NODE_ENV = "production";
+    delete process.env.VEIL_ENABLE_TEST_TIME_OVERRIDE;
+    assert.equal(__playerAccountRouteInternals.readDailyDungeonNowOverride(createRequestWithTestNow("2026-04-07T12:00:00.000Z")), null);
+
+    process.env.NODE_ENV = "test";
+    assert.equal(
+      __playerAccountRouteInternals.readDailyDungeonNowOverride(createRequestWithTestNow("2026-04-07T12:00:00.000Z"))?.toISOString(),
+      "2026-04-07T12:00:00.000Z"
+    );
+  } finally {
+    if (previousNodeEnv === undefined) {
+      process.env.NODE_ENV = "test";
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    if (previousOverride === undefined) {
+      delete process.env.VEIL_ENABLE_TEST_TIME_OVERRIDE;
+    } else {
+      process.env.VEIL_ENABLE_TEST_TIME_OVERRIDE = previousOverride;
+    }
+  }
+});
+
+test("action submission bursts are rate-limited for five seconds", () => {
+  resetActionSubmissionRateLimitState();
+
+  const first = consumeActionSubmissionRateLimit("player-1:campaign");
+  const second = consumeActionSubmissionRateLimit("player-1:campaign");
+  const third = consumeActionSubmissionRateLimit("player-1:campaign", Date.now() + 5_001);
+
+  assert.equal(first.allowed, true);
+  assert.equal(second.allowed, false);
+  assert.equal(second.retryAfterSeconds != null, true);
+  assert.equal(third.allowed, true);
+});
+
+test("verified action checks require server-owned state", () => {
+  const account: Pick<PlayerAccountSnapshot, "dailyDungeonState" | "recentBattleReplays"> = {
+    dailyDungeonState: {
+      dateKey: "2026-04-07",
+      attemptsUsed: 1,
+      claimedRunIds: ["run-claimed"],
+      runs: [
+        {
+          runId: "run-claimed",
+          dungeonId: "shadow-archives",
+          floor: 2,
+          startedAt: "2026-04-07T11:55:00.000Z",
+          rewardClaimedAt: "2026-04-07T12:00:00.000Z"
+        }
+      ]
+    },
+    recentBattleReplays: [
+      {
+        id: "amber-fields:chapter1-ember-watch-battle:player-1",
+        roomId: "amber-fields",
+        playerId: "player-1",
+        battleId: "chapter1-ember-watch-battle",
+        battleKind: "hero",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        startedAt: "2026-04-07T11:30:00.000Z",
+        completedAt: "2026-04-07T11:45:00.000Z",
+        initialState: {
+          id: "chapter1-ember-watch-battle",
+          round: 1,
+          lanes: 1,
+          activeUnitId: "unit-1",
+          turnOrder: ["unit-1"],
+          units: {},
+          environment: [],
+          log: [],
+          rng: { seed: 1, cursor: 0 }
+        },
+        steps: [],
+        result: "attacker_victory"
+      } as PlayerAccountSnapshot["recentBattleReplays"][number]
+    ]
+  };
+
+  assert.equal(hasVerifiedDailyDungeonClaim(account, "run-claimed", "shadow-archives"), true);
+  assert.equal(hasVerifiedDailyDungeonClaim(account, "run-claimed", "other-dungeon"), false);
+  assert.equal(
+    __playerAccountRouteInternals.hasVerifiedCampaignMissionCompletion(account, {
+      mapId: "amber-fields"
+    }),
+    true
+  );
+  assert.equal(
+    __playerAccountRouteInternals.hasVerifiedCampaignMissionCompletion(account, {
+      mapId: "other-map"
+    }),
+    false
+  );
+});

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -1423,9 +1423,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   assert.deepEqual(detailPayload.account.globalResources, { gold: 0, wood: 0, ore: 0 });
 
   const publicReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/battle-replays`);
-  const publicReplayPayload = (await publicReplayResponse.json()) as { items: PlayerBattleReplaySummary[] };
-  assert.equal(publicReplayResponse.status, 200);
-  assert.deepEqual(publicReplayPayload.items, []);
+  assert.equal(publicReplayResponse.status, 401);
 
   const publicAchievementResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/achievements`);
   const publicAchievementPayload = (await publicAchievementResponse.json()) as { items: PlayerAchievementProgress[] };
@@ -1571,9 +1569,7 @@ test("public guest player routes keep only intended public payloads exposed", as
   assert.deepEqual(accountPayload.account.globalResources, { gold: 0, wood: 0, ore: 0 });
 
   const replayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/guest-preview/battle-replays`);
-  const replayPayload = (await replayResponse.json()) as { items: PlayerBattleReplaySummary[] };
-  assert.equal(replayResponse.status, 200);
-  assert.deepEqual(replayPayload.items, []);
+  assert.equal(replayResponse.status, 401);
 
   const eventLogResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/guest-preview/event-log?limit=2`);
   assert.equal(eventLogResponse.status, 401);
@@ -1607,27 +1603,41 @@ test("player account battle replay routes return normalized replay summaries wit
     lastSeenAt: new Date("2026-03-25T09:00:00.000Z").toISOString()
   });
   const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "灰烬领主"
+  });
 
   t.after(async () => {
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
   const detailResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1`
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
   const detailPayload = (await detailResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(detailResponse.status, 200);
   assert.deepEqual(detailPayload.items.map((replay) => replay.id), ["replay-newer"]);
 
   const pagedResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1&offset=1`
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1&offset=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
   const pagedPayload = (await pagedResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(pagedResponse.status, 200);
   assert.deepEqual(pagedPayload.items.map((replay) => replay.id), ["replay-older"]);
 
   const missingResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays`);
-  assert.equal(missingResponse.status, 404);
+  assert.equal(missingResponse.status, 401);
 });
 
 test("player account battle replay routes filter replay summaries by battle metadata", async (t) => {
@@ -1673,7 +1683,12 @@ test("player account battle replay routes filter replay summaries by battle meta
   });
 
   const publicResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-filtered/battle-replays?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`
+    `http://127.0.0.1:${port}/api/player-accounts/player-filtered/battle-replays?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
   const publicPayload = (await publicResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(publicResponse.status, 200);
@@ -1749,7 +1764,12 @@ test("player account battle report routes expose normalized report summaries wit
   });
 
   const publicResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-report/battle-reports?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`
+    `http://127.0.0.1:${port}/api/player-accounts/player-report/battle-reports?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
   const publicPayload = (await publicResponse.json()) as PlayerBattleReportCenter;
   assert.equal(publicResponse.status, 200);
@@ -4553,9 +4573,21 @@ test("referral endpoint credits both accounts exactly once", async (t) => {
 test("campaign mission completion unlocks the next chapter 1 mission and grants rewards", async (t) => {
   const port = 44980 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
-  await store.ensurePlayerAccount({
+  const seededCampaignAccount = await store.ensurePlayerAccount({
     playerId: "campaign-player",
     displayName: "Campaign Hero"
+  });
+  store.seedAccount({
+    ...seededCampaignAccount,
+    recentBattleReplays: [
+      createReplaySummary("campaign-player-chapter1-ember-watch", "2026-04-23T08:00:00.000Z", {
+        playerId: "campaign-player",
+        roomId: "amber-fields",
+        battleId: "chapter1-ember-watch-battle"
+      })
+    ],
+    lastRoomId: "amber-fields",
+    lastSeenAt: new Date().toISOString()
   });
   const server = await startAccountRouteServer(port, store);
   const session = issueAccountAuthSession({
@@ -4773,6 +4805,7 @@ test("completed campaign mission returns 409 for both restart and re-completion 
 test("daily dungeon attempts are capped per day and rewards can only be claimed once per run", async (t) => {
   const port = 45000 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
+  const testNow = "2026-04-07T12:00:00.000Z";
   await store.ensurePlayerAccount({
     playerId: "dungeon-player",
     displayName: "Dungeon Hero"
@@ -4793,7 +4826,8 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
       method: "POST",
       headers: {
         Authorization: `Bearer ${session.token}`,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-Veil-Test-Now": testNow
       },
       body: JSON.stringify({ floor })
     });
@@ -4823,7 +4857,8 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${session.token}`
+        Authorization: `Bearer ${session.token}`,
+        "X-Veil-Test-Now": testNow
       }
     }
   );
@@ -4832,7 +4867,8 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${session.token}`
+        Authorization: `Bearer ${session.token}`,
+        "X-Veil-Test-Now": testNow
       }
     }
   );
@@ -4843,9 +4879,9 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
     eventProgress?: Array<{ eventId: string; delta: number; points: number; objectiveId: string }>;
   };
   const claimAgainPayload = (await claimAgainResponse.json()) as { error: { code: string } };
-  const activeDungeon = resolveActiveDailyDungeon();
+  const activeDungeon = resolveActiveDailyDungeon(new Date(testNow));
   const expectedReward = activeDungeon.floors.find((floor) => floor.floor === 2)?.reward;
-  const activeSeasonalEvent = getActiveSeasonalEvents(resolveSeasonalEvents())[0];
+  const activeSeasonalEvent = getActiveSeasonalEvents(resolveSeasonalEvents(), new Date(testNow))[0];
 
   assert.equal(claimResponse.status, 200);
   assert.equal(claimPayload.claimed, true);


### PR DESCRIPTION
Closes #1665. Closes #1666. Closes #1670.\n\n- Require authenticated owner scope for player battle replay/report routes.\n- Add verified-action guards for campaign completion and seasonal daily dungeon progress.\n- Add short burst protection for sensitive player action submissions.\n\nVerification:\n- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/server/test/action-guard-helpers.test.ts\n- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test --test-name-pattern='campaign mission completion unlocks the next chapter 1 mission and grants rewards|completed campaign mission returns 409 for both restart and re-completion attempts|daily dungeon attempts are capped per day and rewards can only be claimed once per run|player account me battle replay route resolves the current authenticated account' apps/server/test/player-account-routes.test.ts