### PR TITLE
Fix smoke regressions after issue hardening

### DIFF
--- a/apps/client/src/lobby-preferences.ts
+++ b/apps/client/src/lobby-preferences.ts
@@ -1,3 +1,5 @@
+import { resolveRuntimeServerHttpUrl } from "./runtime-targets";
+
 const LOBBY_PREFERENCES_STORAGE_KEY = "project-veil:lobby-preferences";
 const DEFAULT_LOBBY_ROOM_ID = "room-alpha";
 const LOBBY_REQUEST_TIMEOUT_MS = 1200;
@@ -32,8 +34,7 @@ function getLobbyStorage(): Storage | null {
 }
 
 function resolveLobbyApiBaseUrl(): string {
-  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
-  return `${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567`;
+  return resolveRuntimeServerHttpUrl();
 }
 
 function normalizePlayerId(value?: string | null): string {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -3132,10 +3132,8 @@ async function loadDailyQuestBoardFromServer(): Promise<DailyQuestBoard | undefi
   if (!authSession?.token) {
     return undefined;
   }
-  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
-
   try {
-    const response = await fetch(`${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567/api/player-accounts/me/daily-quests`, {
+    const response = await fetch(`${runtimeServerHttpUrl}/api/player-accounts/me/daily-quests`, {
       headers: buildAuthHeaders(authSession.token)
     });
     if (!response.ok) {
@@ -5490,11 +5488,10 @@ async function onClaimDailyQuestReward(questId: string): Promise<void> {
   state.dailyQuestClaimingId = questId;
   state.accountStatus = "正在领取每日任务奖励...";
   render();
-  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
 
   try {
     const response = await fetch(
-      `${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567/api/player-accounts/me/daily-quests/${encodeURIComponent(questId)}/claim`,
+      `${runtimeServerHttpUrl}/api/player-accounts/me/daily-quests/${encodeURIComponent(questId)}/claim`,
       {
       method: "POST",
       headers: buildAuthHeaders(authSession.token)

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -6,6 +6,7 @@ import {
   storeAuthSession,
   type StoredAuthSession
 } from "./auth-session";
+import { resolveRuntimeServerHttpUrl } from "./runtime-targets";
 import { type BattleReplayPlaybackCommand, type BattleReplayPlaybackState, findPlayerBattleReplaySummary, normalizePlayerBattleReportCenter, type PlayerBattleReplayQuery, type PlayerBattleReplaySummary, type PlayerBattleReportCenter, queryPlayerBattleReplaySummaries, restoreBattleReplayPlaybackState } from "@veil/shared/battle";
 import { type AchievementProgressQuery, type EventLogEntry, type EventLogQuery, normalizeEventLogEntries, normalizePlayerProgressionSnapshot, type PlayerAchievementProgress, type PlayerProgressionSnapshot, queryAchievementProgress } from "@veil/shared/event-log";
 import { type ExperimentAssignment, normalizeExperimentAssignments } from "@veil/shared/platform";
@@ -126,8 +127,7 @@ function getPlayerAccountStorage(): Storage | null {
 }
 
 function resolvePlayerAccountApiBaseUrl(): string {
-  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
-  return `${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567`;
+  return resolveRuntimeServerHttpUrl();
 }
 
 function toEventLogQueryString(query?: EventLogQuery): string {

--- a/apps/server/src/domain/account/player-accounts.ts
+++ b/apps/server/src/domain/account/player-accounts.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { applyBattleReplayPlaybackCommand, type BattleReplayPlaybackCommand, buildPlayerBattleReportCenter, findPlayerBattleReplaySummary, type PlayerBattleReplaySummary, queryPlayerBattleReplaySummaries } from "@veil/shared/battle";
+import { applyBattleReplayPlaybackCommand, type BattleReplayPlaybackCommand, type BattleReplayResult, buildPlayerBattleReportCenter, findPlayerBattleReplaySummary, type PlayerBattleReplaySummary, queryPlayerBattleReplaySummaries } from "@veil/shared/battle";
 import { normalizeCosmeticInventory } from "@veil/shared/economy";
 import { appendEventLogEntries, buildPlayerProgressionSnapshot, getAchievementDefinitions, normalizeAchievementProgressQuery, normalizeEventLogQuery, queryAchievementProgress, queryEventLogEntries } from "@veil/shared/event-log";
-import type { SeasonalEventState } from "@veil/shared/models";
+import type { BattleState, DailyDungeonRunRecord, SeasonalEventState } from "@veil/shared/models";
 import { DEFAULT_TUTORIAL_STEP, getRankDivisionForRating, isTutorialComplete, summarizePlayerMailbox } from "@veil/shared/progression";
 import {
   createDailyQuestClaimEventLogEntry,
@@ -24,6 +24,7 @@ import {
 import { recordAuthInvalidCredentials, removeAuthAccountSession, removeAuthAccountSessionsForPlayer } from "@server/domain/ops/observability";
 import type {
   PlayerAccountProfilePatch,
+  PlayerAccountProgressPatch,
   PlayerAccountSnapshot,
   PlayerEventHistoryQuery,
   RoomSnapshotStore,
@@ -275,6 +276,71 @@ function hasVerifiedCampaignMissionCompletion(account: PlayerAccountSnapshot, mi
       (replay) => replay.roomId === mission.mapId && replay.result === "attacker_victory"
     ) ?? false
   );
+}
+
+function areTestEndpointsEnabled(): boolean {
+  return process.env.VEIL_ENABLE_TEST_ENDPOINTS === "1";
+}
+
+function readRequiredString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function createTestVerifiedBattleReplay(input: {
+  playerId: string;
+  roomId: string;
+  battleId: string;
+  result: BattleReplayResult;
+  completedAt: string;
+}): PlayerBattleReplaySummary {
+  const initialState: BattleState = {
+    id: input.battleId,
+    round: 1,
+    lanes: 1,
+    activeUnitId: "unit-1",
+    turnOrder: ["unit-1"],
+    units: {
+      "unit-1": {
+        id: "unit-1",
+        camp: "attacker",
+        templateId: "hero_guard_basic",
+        lane: 0,
+        stackName: "Test Guard",
+        initiative: 4,
+        attack: 2,
+        defense: 2,
+        minDamage: 1,
+        maxDamage: 2,
+        currentHp: 10,
+        count: 1,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false
+      }
+    },
+    unitCooldowns: {
+      "unit-1": {}
+    },
+    environment: [],
+    log: [],
+    rng: { seed: 1, cursor: 0 }
+  };
+
+  return {
+    id: `test-proof:${input.playerId}:${input.battleId}`,
+    roomId: input.roomId,
+    playerId: input.playerId,
+    battleId: input.battleId,
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    neutralArmyId: "test-neutral-army",
+    startedAt: input.completedAt,
+    completedAt: input.completedAt,
+    initialState,
+    steps: [],
+    result: input.result
+  };
 }
 
 function sendActionSubmissionRateLimited(response: ServerResponse, retryAfterSeconds?: number): void {
@@ -970,6 +1036,153 @@ export function registerPlayerAccountRoutes(
 
     next();
   });
+
+  if (areTestEndpointsEnabled()) {
+    app.post("/api/test/player-accounts/:playerId/action-proofs", async (request, response) => {
+      if (!isAdminAuthorized(request)) {
+        sendJson(response, 403, {
+          error: {
+            code: "forbidden",
+            message: "Invalid admin token"
+          }
+        });
+        return;
+      }
+
+      if (!store) {
+        sendJson(response, 503, {
+          error: {
+            code: "player_account_persistence_unavailable",
+            message: "Player account action proof seeding requires configured room persistence storage"
+          }
+        });
+        return;
+      }
+
+      try {
+        const playerId = request.params.playerId?.trim();
+        if (!playerId) {
+          sendNotFound(response);
+          return;
+        }
+
+        const body = (await readJsonBody(request)) as {
+          campaignReplays?: Array<{
+            roomId?: unknown;
+            battleId?: unknown;
+            result?: unknown;
+          }>;
+          dailyDungeonClaims?: Array<{
+            runId?: unknown;
+            dungeonId?: unknown;
+            floor?: unknown;
+          }>;
+        };
+
+        const account =
+          (await store.loadPlayerAccount(playerId)) ??
+          (await store.ensurePlayerAccount({
+            playerId,
+            displayName: playerId
+          }));
+        const completedAt = new Date().toISOString();
+        const campaignReplays = (Array.isArray(body.campaignReplays) ? body.campaignReplays : [])
+          .map((entry, index) => {
+            const roomId = readRequiredString(entry.roomId);
+            if (!roomId) {
+              return null;
+            }
+            const battleId = readRequiredString(entry.battleId) ?? `${roomId}-test-battle-${index + 1}`;
+            const result = entry.result === "defender_victory" ? "defender_victory" : "attacker_victory";
+            return createTestVerifiedBattleReplay({
+              playerId,
+              roomId,
+              battleId,
+              result,
+              completedAt
+            });
+          })
+          .filter((entry): entry is PlayerBattleReplaySummary => Boolean(entry));
+        const dailyDungeonClaims: DailyDungeonRunRecord[] = [];
+        for (const [index, entry] of (Array.isArray(body.dailyDungeonClaims) ? body.dailyDungeonClaims : []).entries()) {
+          const runId = readRequiredString(entry.runId);
+          const dungeonId = readRequiredString(entry.dungeonId);
+          if (!runId || !dungeonId) {
+            continue;
+          }
+          const floor = Math.max(1, Math.floor(typeof entry.floor === "number" && Number.isFinite(entry.floor) ? entry.floor : index + 1));
+          dailyDungeonClaims.push({
+            runId,
+            dungeonId,
+            floor,
+            startedAt: completedAt,
+            rewardClaimedAt: completedAt
+          });
+        }
+
+        const existingDailyDungeonState = account.dailyDungeonState ?? {
+          dateKey: completedAt.slice(0, 10),
+          attemptsUsed: 0,
+          claimedRunIds: [],
+          runs: []
+        };
+        const dailyDungeonRunIds = new Set(dailyDungeonClaims.map((entry) => entry.runId));
+        const nextDailyDungeonState =
+          dailyDungeonClaims.length > 0
+            ? {
+                ...existingDailyDungeonState,
+                attemptsUsed: Math.max(existingDailyDungeonState.attemptsUsed ?? 0, dailyDungeonClaims.length),
+                claimedRunIds: Array.from(
+                  new Set([...(existingDailyDungeonState.claimedRunIds ?? []), ...dailyDungeonClaims.map((entry) => entry.runId)])
+                ).sort((left, right) => left.localeCompare(right)),
+                runs: [
+                  ...dailyDungeonClaims,
+                  ...(existingDailyDungeonState.runs ?? []).filter((entry) => !dailyDungeonRunIds.has(entry.runId))
+                ]
+              }
+            : undefined;
+
+        const progressPatch: PlayerAccountProgressPatch = {};
+        if (campaignReplays.length > 0) {
+          progressPatch.recentBattleReplays = [...campaignReplays, ...(account.recentBattleReplays ?? [])];
+        }
+        if (nextDailyDungeonState) {
+          progressPatch.dailyDungeonState = nextDailyDungeonState;
+        }
+
+        const updatedAccount =
+          campaignReplays.length > 0 || nextDailyDungeonState
+            ? await store.savePlayerAccountProgress(playerId, progressPatch)
+            : account;
+
+        sendJson(response, 200, {
+          seeded: {
+            campaignReplays: campaignReplays.length,
+            dailyDungeonClaims: dailyDungeonClaims.length
+          },
+          account: toPublicPlayerAccount(updatedAccount)
+        });
+      } catch (error) {
+        if (error instanceof PayloadTooLargeError) {
+          sendJson(response, 413, {
+            error: toErrorPayload(error)
+          });
+          return;
+        }
+        if (error instanceof SyntaxError) {
+          sendJson(response, 400, {
+            error: {
+              code: "invalid_json",
+              message: "Request body must be valid JSON"
+            }
+          });
+          return;
+        }
+
+        sendJson(response, 500, { error: toErrorPayload(error) });
+      }
+    });
+  }
 
   app.get("/api/player-accounts", async (request, response) => {
     if (!store) {

--- a/apps/server/src/infra/dev-server.ts
+++ b/apps/server/src/infra/dev-server.ts
@@ -208,7 +208,7 @@ export interface DevServerBootstrapDependencies {
   createRedisPresence(redisUrl: string): { shutdown(): Promise<void> | void };
   createRedisDriver(redisUrl: string): { shutdown(): Promise<void> | void };
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
-  registerAnalyticsRoutes(app: unknown): void;
+  registerAnalyticsRoutes(app: unknown, options?: { enableTestRoutes?: boolean }): void;
   registerClientErrorRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
@@ -330,7 +330,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     createRedisPresence,
     createRedisDriver,
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
-    registerAnalyticsRoutes: (app) => registerAnalyticsRoutes(app as never),
+    registerAnalyticsRoutes: (app, options) => registerAnalyticsRoutes(app as never, options),
     registerClientErrorRoutes: (app, store) => registerClientErrorRoutes(app as never, store as RoomSnapshotStore | null),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
@@ -493,7 +493,9 @@ export async function startDevServer(
   deps.registerHttpRateLimitMiddleware(expressApp);
   deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
-  deps.registerAnalyticsRoutes(expressApp);
+  deps.registerAnalyticsRoutes(expressApp, {
+    enableTestRoutes: process.env.VEIL_ENABLE_TEST_ENDPOINTS === "1"
+  });
   deps.registerClientErrorRoutes(expressApp, effectiveSnapshotStore);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -227,9 +227,6 @@ export default defineConfig({
   reporter: SHARED_REPORTER,
   use: {
     baseURL: clientOrigin,
-    extraHTTPHeaders: {
-      "x-veil-admin-token": adminToken
-    },
     headless: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",

--- a/tests/e2e/battle-replay-smoke.spec.ts
+++ b/tests/e2e/battle-replay-smoke.spec.ts
@@ -124,13 +124,17 @@ test("battle replay center smoke persists a resolved PvP battle and supports acc
         let replaySummary: PlayerBattleReplaySummary | null = null;
         let replayId: string | null = null;
         const token = await createGuestSessionToken(request, replayPlayerId);
+        const authHeaders = {
+          Authorization: `Bearer ${token}`
+        };
 
         await expect
           .poll(
             async () => {
               const payload = await getJson<{ items: PlayerBattleReplaySummary[] }>(
                 request,
-                `/api/player-accounts/${encodeURIComponent(replayPlayerId)}/battle-replays`
+                `/api/player-accounts/${encodeURIComponent(replayPlayerId)}/battle-replays`,
+                authHeaders
               );
               replaySummary = payload.items.find((item) => item.battleId === battleId) ?? null;
               replayId = replaySummary?.id ?? null;
@@ -149,9 +153,7 @@ test("battle replay center smoke persists a resolved PvP battle and supports acc
         const detailPayload = await getJson<{ replay: PlayerBattleReplaySummary }>(
           request,
           `/api/player-accounts/${encodeURIComponent(replayPlayerId)}/battle-replays/${encodeURIComponent(replayId!)}`,
-          {
-            Authorization: `Bearer ${token}`
-          }
+          authHeaders
         );
         expect(detailPayload.replay.battleId).toBe(battleId);
         expect(detailPayload.replay.steps.length).toBeGreaterThan(0);

--- a/tests/e2e/campaign-mission-flow.spec.ts
+++ b/tests/e2e/campaign-mission-flow.spec.ts
@@ -37,6 +37,7 @@ interface PlayerProfilePayload {
 interface CampaignMissionPayload {
   id: string;
   chapterId: string;
+  mapId?: string;
   name?: string;
   status?: string;
   introDialogue?: Array<{ id?: string; text?: string }>;
@@ -122,7 +123,36 @@ async function createGuestSessionToken(request: APIRequestContext, playerId: str
   return payload.session?.token ?? "";
 }
 
-async function completeMission(request: APIRequestContext, token: string, missionId: string): Promise<CampaignMissionCompletePayload> {
+async function seedVerifiedMissionReplay(
+  request: APIRequestContext,
+  playerId: string,
+  missionId: string,
+  mapId: string
+): Promise<void> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/player-accounts/${encodeURIComponent(playerId)}/action-proofs`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    },
+    data: {
+      campaignReplays: [
+        {
+          roomId: mapId,
+          battleId: `${missionId}-verified-smoke`
+        }
+      ]
+    }
+  });
+  expect(response.status(), `expected ${missionId} verified replay seeding to succeed`).toBe(200);
+}
+
+async function completeMission(
+  request: APIRequestContext,
+  token: string,
+  playerId: string,
+  missionId: string,
+  mapId: string
+): Promise<CampaignMissionCompletePayload> {
+  await seedVerifiedMissionReplay(request, playerId, missionId, mapId);
   const response = await request.post(`${SERVER_BASE_URL}/api/player-accounts/me/campaign/${missionId}/complete`, {
     headers: buildAuthHeaders(token)
   });
@@ -207,7 +237,7 @@ test("campaign mission smoke covers mission start, reward settlement, unlock pro
     expect(startPayload.mission?.id).toBe(FIRST_MISSION_ID);
     expect(startPayload.mission?.status).toBe("available");
 
-    const completePayload = await completeMission(request, token, FIRST_MISSION_ID);
+    const completePayload = await completeMission(request, token, playerId, FIRST_MISSION_ID, FIRST_MISSION_MAP_ID);
     expect(completePayload.completed).toBe(true);
     expect(completePayload.mission?.id).toBe(FIRST_MISSION_ID);
     expect(completePayload.mission?.status).toBe("completed");
@@ -271,8 +301,21 @@ test("campaign mission smoke covers mission start, reward settlement, unlock pro
   });
 
   await test.step("api: clearing the rest of chapter 1 unlocks chapter 2", async () => {
+    const latestCampaignResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me/campaign`, {
+      headers: authHeaders
+    });
+    expect(latestCampaignResponse.status()).toBe(200);
+    const latestCampaignPayload = (await latestCampaignResponse.json()) as CampaignSummaryPayload;
+    const missionMapIds = new Map(
+      (latestCampaignPayload.campaign?.missions ?? [])
+        .filter((mission) => mission.id && mission.mapId)
+        .map((mission) => [mission.id, mission.mapId] as const)
+    );
+
     for (const missionId of CHAPTER_ONE_MISSION_IDS.slice(1)) {
-      await completeMission(request, token, missionId);
+      const mapId = missionMapIds.get(missionId);
+      expect(mapId, `expected ${missionId} to expose a campaign mapId`).toBeTruthy();
+      await completeMission(request, token, playerId, missionId, mapId ?? "");
     }
 
     const chapterUnlockResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me/campaign`, {

--- a/tests/e2e/onboarding-funnel.spec.ts
+++ b/tests/e2e/onboarding-funnel.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { loadDailyQuestConfig } from "../../apps/server/src/domain/economy/daily-quest-config.ts";
 import { rotateDailyQuests } from "../../apps/server/src/domain/battle/event-engine.ts";
 import { expect, test } from "./fixtures";
@@ -11,6 +11,7 @@ import {
   waitForLobbyReady,
   withSmokeDiagnostics
 } from "./smoke-helpers";
+import { ADMIN_TOKEN, SERVER_BASE_URL } from "./runtime-targets";
 
 interface AuthSessionSnapshot {
   playerId?: string;
@@ -67,6 +68,7 @@ interface CampaignSummaryPayload {
     missions?: Array<{
       id?: string;
       chapterId?: string;
+      mapId?: string;
       name?: string;
       status?: string;
       introDialogue?: Array<{ id?: string; text?: string }>;
@@ -302,7 +304,44 @@ async function startCampaignMission(page: Page, campaignId: string, missionId: s
   return result.payload;
 }
 
-async function completeCampaignMission(page: Page, missionId: string): Promise<CampaignCompletePayload> {
+async function seedVerifiedCampaignReplay(
+  request: APIRequestContext,
+  missionId: string,
+  proofContext: {
+    playerId: string;
+    mapId: string;
+  }
+): Promise<void> {
+  const { mapId, playerId } = proofContext;
+  expect(playerId, `completeCampaignMission requires a player id for ${missionId}`).toBeTruthy();
+  expect(mapId, `completeCampaignMission requires a campaign map id for ${missionId}`).toBeTruthy();
+
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/player-accounts/${encodeURIComponent(playerId)}/action-proofs`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    },
+    data: {
+      campaignReplays: [
+        {
+          roomId: mapId,
+          battleId: `${missionId}-onboarding-smoke`
+        }
+      ]
+    }
+  });
+  expect(response.status(), `seed verified campaign replay failed: ${await response.text()}`).toBe(200);
+}
+
+async function completeCampaignMission(
+  page: Page,
+  request: APIRequestContext,
+  missionId: string,
+  proofContext: {
+    playerId: string;
+    mapId: string;
+  }
+): Promise<CampaignCompletePayload> {
+  await seedVerifiedCampaignReplay(request, missionId, proofContext);
   const result = await fetchAuthedJson<CampaignCompletePayload>(page, `/api/player-accounts/me/campaign/${missionId}/complete`, {
     method: "POST"
   });
@@ -422,7 +461,8 @@ test("onboarding funnel: tutorial progression advances step 1 to step 3 in order
 });
 
 test("onboarding funnel: tutorial completion hands off to chapter 1, settles the first battle, and unlocks the first claim", async ({
-  page
+  page,
+  request
 }, testInfo) => {
   test.setTimeout(60_000);
   const roomId = buildRoomId("onb-main");
@@ -454,7 +494,10 @@ test("onboarding funnel: tutorial completion hands off to chapter 1, settles the
 
     const campaignSummary = await fetchCampaignSummary(page);
     expect(campaignSummary.nextMissionId).toBe(firstMissionId);
-    expect(campaignSummary.missions?.find((mission) => mission.id === firstMissionId)?.status).toBe("available");
+    const firstMission = campaignSummary.missions?.find((mission) => mission.id === firstMissionId);
+    expect(firstMission?.status).toBe("available");
+    const firstMissionMapId = firstMission?.mapId ?? "";
+    expect(firstMissionMapId).toBeTruthy();
     expect(campaignSummary.missions?.find((mission) => mission.id === "chapter1-thornwall-road")?.status).toBe("locked");
 
     const missionDetail = await fetchAuthedJson<{ mission?: CampaignSummaryPayload["campaign"]["missions"][number] }>(
@@ -472,7 +515,10 @@ test("onboarding funnel: tutorial completion hands off to chapter 1, settles the
     expect(startPayload.mission?.id).toBe(firstMissionId);
     expect(startPayload.mission?.status).toBe("available");
 
-    const completePayload = await completeCampaignMission(page, firstMissionId);
+    const completePayload = await completeCampaignMission(page, request, firstMissionId, {
+      playerId,
+      mapId: firstMissionMapId
+    });
     expect(completePayload.completed).toBe(true);
     expect(completePayload.mission?.id).toBe(firstMissionId);
     expect(completePayload.mission?.status).toBe("completed");

--- a/tests/e2e/seasonal-event-lifecycle.spec.ts
+++ b/tests/e2e/seasonal-event-lifecycle.spec.ts
@@ -116,7 +116,26 @@ async function fetchActiveEvent(request: APIRequestContext, token: string): Prom
   return event as SeasonalEventResponse;
 }
 
-async function submitProgress(request: APIRequestContext, token: string, actionId: string): Promise<ProgressPayload> {
+async function seedVerifiedDailyDungeonClaim(request: APIRequestContext, playerId: string, runId: string): Promise<void> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/player-accounts/${encodeURIComponent(playerId)}/action-proofs`, {
+    headers: {
+      "x-veil-admin-token": ADMIN_TOKEN
+    },
+    data: {
+      dailyDungeonClaims: [
+        {
+          runId,
+          dungeonId: OBJECTIVE_DUNGEON_ID,
+          floor: 1
+        }
+      ]
+    }
+  });
+  expect(response.status(), `expected ${runId} daily dungeon claim proof seeding to succeed`).toBe(200);
+}
+
+async function submitProgress(request: APIRequestContext, token: string, playerId: string, actionId: string): Promise<ProgressPayload> {
+  await seedVerifiedDailyDungeonClaim(request, playerId, actionId);
   const response = await request.post(`${SERVER_BASE_URL}/api/events/${EVENT_ID}/progress`, {
     headers: buildAuthHeaders(token),
     data: {
@@ -185,7 +204,7 @@ test("seasonal event smoke covers progress submission, reward claim settlement, 
 
   await test.step("api: repeated progress submissions unlock the event rewards and place the player on the leaderboard", async () => {
     for (let index = 1; index <= 5; index += 1) {
-      const payload = await submitProgress(request, token, `seasonal-progress-${index}`);
+      const payload = await submitProgress(request, token, playerId, `seasonal-progress-${index}`);
       expect(payload.applied).toBe(true);
       expect(payload.eventProgress).toEqual({
         eventId: EVENT_ID,


### PR DESCRIPTION
## Summary
- Restore dynamic server target usage in H5 account/lobby/daily-quest flows.
- Re-enable test analytics capture only behind VEIL_ENABLE_TEST_ENDPOINTS.
- Add an admin-gated test action-proof seeding endpoint and update smoke specs to use verified replay/claim proofs.
- Fix battle replay smoke polling to use authenticated replay list requests.

## Test Plan
- npx -p node@22 npx playwright test tests/e2e/onboarding-funnel.spec.ts --project=smoke --workers=1
- npx -p node@22 npm test -- e2e:smoke
- npx -p node@22 npm run typecheck -- client:h5
- npx -p node@22 npm run typecheck -- server
- npx -p node@22 npx playwright test tests/e2e/battle-replay-smoke.spec.ts --project=multiplayer-smoke --workers=1
- npx -p node@22 npm test -- e2e:multiplayer:smoke
- npx -p node@22 npm test