### PR TITLE
fix: cascade gdpr account deletion

### DIFF
--- a/apps/server/src/persistence/mysql/store.ts
+++ b/apps/server/src/persistence/mysql/store.ts
@@ -8894,6 +8894,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const deletedAt = normalizePrivacyConsentAt(input.deletedAt) ?? new Date().toISOString();
     const anonymizedDisplayName = `deleted-${normalizedPlayerId}`;
+    const anonymizedPlayerReference = `deleted-player:${normalizedPlayerId}`;
     const retainedFinancialPlayerToken = createDeletedFinancialRecordPseudonym();
 
     const connection = await this.pool.getConnection();
@@ -8961,21 +8962,54 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         [normalizedPlayerId]
       );
       await connection.query(
+        `DELETE FROM \`${MYSQL_GEM_LEDGER_TABLE}\`
+         WHERE player_id = ?`,
+        [normalizedPlayerId]
+      );
+      await connection.query(
+        `DELETE FROM \`${MYSQL_SHOP_PURCHASE_TABLE}\`
+         WHERE player_id = ?`,
+        [normalizedPlayerId]
+      );
+      await connection.query(
+        `DELETE FROM \`${MYSQL_PLAYER_ROOM_PROFILE_TABLE}\`
+         WHERE player_id = ?`,
+        [normalizedPlayerId]
+      );
+      await connection.query(
+        `DELETE FROM \`${MYSQL_PLAYER_NAME_RESERVATION_TABLE}\`
+         WHERE player_id = ?`,
+        [normalizedPlayerId]
+      );
+      await connection.query(
+        `UPDATE \`${MYSQL_PLAYER_REPORT_TABLE}\`
+         SET reporter_id = ?
+         WHERE reporter_id = ?`,
+        [anonymizedPlayerReference, normalizedPlayerId]
+      );
+      await connection.query(
+        `UPDATE \`${MYSQL_PLAYER_REPORT_TABLE}\`
+         SET target_id = ?
+         WHERE target_id = ?`,
+        [anonymizedPlayerReference, normalizedPlayerId]
+      );
+      await connection.query(
+        `UPDATE \`${MYSQL_GUILD_AUDIT_LOG_TABLE}\`
+         SET actor_player_id = ?
+         WHERE actor_player_id = ?`,
+        [anonymizedPlayerReference, normalizedPlayerId]
+      );
+      await connection.query(
         `UPDATE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
-         INNER JOIN \`${MYSQL_PAYMENT_ORDER_TABLE}\`
-           ON \`${MYSQL_PAYMENT_ORDER_TABLE}\`.order_id = \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.order_id
-         SET \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.player_id = ?
-         WHERE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.player_id = ?
-           AND \`${MYSQL_PAYMENT_ORDER_TABLE}\`.player_id = ?
-           AND \`${MYSQL_PAYMENT_ORDER_TABLE}\`.status IN (?, ?)`,
-        [retainedFinancialPlayerToken, normalizedPlayerId, normalizedPlayerId, "settled", "dead_letter"]
+         SET player_id = ?
+         WHERE player_id = ?`,
+        [retainedFinancialPlayerToken, normalizedPlayerId]
       );
       await connection.query(
         `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
          SET player_id = ?
-         WHERE player_id = ?
-           AND status IN (?, ?)`,
-        [retainedFinancialPlayerToken, normalizedPlayerId, "settled", "dead_letter"]
+         WHERE player_id = ?`,
+        [retainedFinancialPlayerToken, normalizedPlayerId]
       );
 
       const verificationChecks = [
@@ -9037,6 +9071,36 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         {
           label: MYSQL_SEASON_REWARD_LOG_TABLE,
           sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_GEM_LEDGER_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_GEM_LEDGER_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_SHOP_PURCHASE_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_SHOP_PURCHASE_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_PLAYER_ROOM_PROFILE_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_PLAYER_ROOM_PROFILE_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_PLAYER_NAME_RESERVATION_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_PLAYER_NAME_RESERVATION_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_PLAYER_REPORT_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_PLAYER_REPORT_TABLE}\` WHERE reporter_id = ? OR target_id = ?`,
+          params: [normalizedPlayerId, normalizedPlayerId]
+        },
+        {
+          label: MYSQL_GUILD_AUDIT_LOG_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_GUILD_AUDIT_LOG_TABLE}\` WHERE actor_player_id = ?`,
           params: [normalizedPlayerId]
         },
         {

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -657,19 +657,32 @@ test("deletePlayerAccount deletes dependent rows, verifies cascade cleanup, and 
   assert.ok(queries.some((entry) => /DELETE FROM `battle_snapshots`/.test(entry.sql)));
   assert.ok(queries.some((entry) => /DELETE FROM `leaderboard_season_archives`/.test(entry.sql)));
   assert.ok(queries.some((entry) => /DELETE FROM `season_reward_log`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /DELETE FROM `gem_ledger`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /DELETE FROM `shop_purchases`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /DELETE FROM `player_room_profiles`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /DELETE FROM `player_name_reservations`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /UPDATE `player_reports`[\s\S]*SET reporter_id = \?/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /UPDATE `player_reports`[\s\S]*SET target_id = \?/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /UPDATE `guild_audit_logs`[\s\S]*SET actor_player_id = \?/.test(entry.sql)));
   const retainedOrderUpdate = queries.find((entry) => /UPDATE `orders`/.test(entry.sql));
   assert.ok(retainedOrderUpdate);
   assert.equal(retainedOrderUpdate?.params[1], "player-1");
   assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
-  assert.deepEqual(retainedOrderUpdate?.params.slice(2), ["settled", "dead_letter"]);
+  assert.equal(retainedOrderUpdate?.params.length, 2);
   const retainedReceiptUpdate = queries.find((entry) => /UPDATE `payment_receipts`/.test(entry.sql));
   assert.ok(retainedReceiptUpdate);
   assert.equal(retainedReceiptUpdate?.params[0], retainedOrderUpdate?.params[0]);
-  assert.deepEqual(retainedReceiptUpdate?.params.slice(1), ["player-1", "player-1", "settled", "dead_letter"]);
-  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
+  assert.deepEqual(retainedReceiptUpdate?.params.slice(1), ["player-1"]);
+  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 20);
   assert.ok(
     queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `leaderboard_season_archives`/.test(entry.sql))
   );
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `gem_ledger`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `shop_purchases`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `player_room_profiles`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `player_name_reservations`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `player_reports`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `guild_audit_logs`/.test(entry.sql)));
   const updateQuery = queries.find((entry) => /UPDATE `player_accounts`/.test(entry.sql));
   assert.ok(updateQuery);
   assert.equal(updateQuery?.params[0], "deleted-player-1");
@@ -789,7 +802,7 @@ test("deletePlayerAccount rolls back when unsettled orders keep a raw player id"
   assert.ok(retainedOrderUpdate);
   assert.equal(retainedOrderUpdate?.params[1], "player-1");
   assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
-  assert.deepEqual(retainedOrderUpdate?.params.slice(2), ["settled", "dead_letter"]);
+  assert.equal(retainedOrderUpdate?.params.length, 2);
   assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `orders`/.test(entry.sql)));
   assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
 });
@@ -848,8 +861,7 @@ test("deletePlayerAccount rolls back when payment receipts verification still fi
   const retainedReceiptUpdate = queries.find((entry) => /UPDATE `payment_receipts`/.test(entry.sql));
   assert.ok(retainedReceiptUpdate);
   assert.equal(retainedReceiptUpdate?.params[1], "player-1");
-  assert.equal(retainedReceiptUpdate?.params[2], "player-1");
-  assert.deepEqual(retainedReceiptUpdate?.params.slice(3), ["settled", "dead_letter"]);
+  assert.equal(retainedReceiptUpdate?.params.length, 2);
   assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `payment_receipts`/.test(entry.sql)));
   assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
 });

--- a/apps/server/test/persistence-account-delete-gdpr-cascade.test.ts
+++ b/apps/server/test/persistence-account-delete-gdpr-cascade.test.ts
@@ -116,7 +116,7 @@ test("deletePlayerAccount removes GDPR-linked name history, guild chat, and refe
       (entry) => /SELECT COUNT\(\*\) AS total FROM `referrals` WHERE referrer_id = \? OR new_player_id = \?/.test(entry.sql)
     )
   );
-  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
+  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 20);
 });
 
 test("deletePlayerAccount rolls back when guild chat rows remain after author cleanup", async () => {


### PR DESCRIPTION
Closes #1680\n\nSummary:\n- delete remaining account-linked ledger, purchase, profile, name-reservation rows\n- pseudonymize report and guild audit references\n- extend post-delete verification coverage\n\nValidation:\n- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/persistence-account-credentials.test.ts apps/server/test/persistence-account-delete-gdpr-cascade.test.ts\n- npm run typecheck -- server