### PR TITLE
fix: authenticate analytics ingest

### DIFF
--- a/apps/server/src/domain/ops/analytics.ts
+++ b/apps/server/src/domain/ops/analytics.ts
@@ -1,5 +1,7 @@
-import { type AnalyticsEvent, type AnalyticsEventName, createAnalyticsEvent } from "@veil/shared/platform";
+import { ANALYTICS_EVENT_CATALOG, type AnalyticsEvent, type AnalyticsEventName, createAnalyticsEvent } from "@veil/shared/platform";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
+import type { RoomSnapshotStore } from "@server/persistence";
 
 const ANALYTICS_BUFFER_FLUSH_SIZE = 20;
 const ANALYTICS_BUFFER_FLUSH_DELAY_MS = 250;
@@ -74,6 +76,8 @@ interface AnalyticsRuntimeDependencies {
 
 interface AnalyticsRouteRegistrationOptions {
   enableTestRoutes?: boolean;
+  store?: RoomSnapshotStore | null;
+  allowedOrigins?: string[];
 }
 
 const defaultAnalyticsRuntimeDependencies: AnalyticsRuntimeDependencies = {
@@ -122,6 +126,10 @@ class PayloadTooLargeError extends Error {
 }
 
 const MAX_ANALYTICS_REQUEST_BYTES = 256 * 1024;
+const MAX_ANALYTICS_EVENTS_PER_REQUEST = 50;
+const ANALYTICS_INGEST_RATE_LIMIT_WINDOW_MS = 60_000;
+const ANALYTICS_INGEST_RATE_LIMIT_MAX = 120;
+const analyticsIngestRateLimitByPlayer = new Map<string, number[]>();
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
   const parsed = Number(value);
@@ -153,6 +161,94 @@ function recordIngestedEvents(events: Array<{ name?: unknown; source?: unknown }
   for (const event of events) {
     incrementCounter(analyticsPipelineCounters.ingestedByKey, buildAnalyticsCounterKey(event));
   }
+}
+
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() || null;
+  }
+  return value?.trim() || null;
+}
+
+function parseAllowedOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.VEIL_ANALYTICS_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+}
+
+function applyAnalyticsCors(
+  request: IncomingMessage,
+  response: ServerResponse,
+  allowedOrigins: string[] = parseAllowedOrigins()
+): void {
+  const origin = readHeaderValue(request.headers.origin);
+  if (origin && allowedOrigins.includes(origin)) {
+    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Vary", "Origin");
+  }
+  response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+}
+
+function sendUnauthorized(response: ServerResponse, code = "unauthorized"): void {
+  sendJson(response, 401, {
+    error: {
+      code,
+      message: "Analytics ingestion requires an authenticated player session"
+    }
+  });
+}
+
+function sendTooManyRequests(response: ServerResponse): void {
+  sendJson(response, 429, {
+    error: {
+      code: "analytics_rate_limited",
+      message: "Too many analytics batches submitted for this player"
+    }
+  });
+}
+
+function consumeAnalyticsIngestRateLimit(playerId: string, nowMs = Date.now()): boolean {
+  const cutoff = nowMs - ANALYTICS_INGEST_RATE_LIMIT_WINDOW_MS;
+  const timestamps = analyticsIngestRateLimitByPlayer.get(playerId)?.filter((timestamp) => timestamp >= cutoff) ?? [];
+  if (timestamps.length >= ANALYTICS_INGEST_RATE_LIMIT_MAX) {
+    analyticsIngestRateLimitByPlayer.set(playerId, timestamps);
+    return false;
+  }
+  timestamps.push(nowMs);
+  analyticsIngestRateLimitByPlayer.set(playerId, timestamps);
+  return true;
+}
+
+function normalizeClientAnalyticsEvents(payload: unknown, playerId: string): AnalyticsEvent[] {
+  const rawEvents = Array.isArray((payload as { events?: unknown[] } | null)?.events)
+    ? ((payload as { events: unknown[] }).events ?? [])
+    : [];
+
+  if (rawEvents.length > MAX_ANALYTICS_EVENTS_PER_REQUEST) {
+    throw new Error(`analytics request accepts at most ${MAX_ANALYTICS_EVENTS_PER_REQUEST} events`);
+  }
+
+  return rawEvents.map((event) => {
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      throw new Error("analytics event must be an object");
+    }
+    const candidate = event as Record<string, unknown>;
+    if (typeof candidate.name !== "string" || !(candidate.name in ANALYTICS_EVENT_CATALOG)) {
+      throw new Error("analytics event name is not allowed");
+    }
+    if (candidate.source !== undefined && typeof candidate.source !== "string") {
+      throw new Error("analytics event source must be a string");
+    }
+    if (candidate.payload !== undefined && (!candidate.payload || typeof candidate.payload !== "object" || Array.isArray(candidate.payload))) {
+      throw new Error("analytics event payload must be an object");
+    }
+    return {
+      ...candidate,
+      playerId
+    } as AnalyticsEvent;
+  });
 }
 
 function recordFlushedEvents(events: Array<{ name?: unknown; source?: unknown }>): void {
@@ -344,6 +440,7 @@ export function resetAnalyticsRuntimeDependencies(): void {
   analyticsPipelineCounters.lastErrorMessage = null;
   analyticsPipelineCounters.ingestedByKey.clear();
   analyticsPipelineCounters.flushedByKey.clear();
+  analyticsIngestRateLimitByPlayer.clear();
 }
 
 export function resetCapturedAnalyticsEventsForTest(): void {
@@ -457,9 +554,7 @@ export function registerAnalyticsRoutes(
   options: AnalyticsRouteRegistrationOptions = {}
 ): void {
   app.use((request, response, next) => {
-    response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    applyAnalyticsCors(request, response, options.allowedOrigins);
 
     if (request.method === "OPTIONS") {
       response.statusCode = 204;
@@ -505,13 +600,22 @@ export function registerAnalyticsRoutes(
 
   app.post("/api/analytics/events", async (request, response) => {
     try {
+      const authResult = await validateAuthSessionFromRequest(request, options.store ?? null);
+      if (!authResult.session) {
+        sendUnauthorized(response, authResult.errorCode ?? "unauthorized");
+        return;
+      }
+      if (!consumeAnalyticsIngestRateLimit(authResult.session.playerId)) {
+        sendTooManyRequests(response);
+        return;
+      }
       const payload = await readJsonBody(request);
       const config = resolveAnalyticsPipelineConfig();
       emitAnalyticsAlerts(config);
-      const events = Array.isArray((payload as { events?: unknown[] } | null)?.events)
-        ? ((payload as { events: AnalyticsEvent[] }).events ?? [])
-        : [];
-      capturedAnalyticsEvents.push(...events);
+      const events = normalizeClientAnalyticsEvents(payload, authResult.session.playerId);
+      if (options.enableTestRoutes) {
+        capturedAnalyticsEvents.push(...events);
+      }
       pendingEvents.push(...events);
       recordIngestedEvents(events);
       scheduleFlush();

--- a/apps/server/src/infra/dev-server.ts
+++ b/apps/server/src/infra/dev-server.ts
@@ -208,7 +208,7 @@ export interface DevServerBootstrapDependencies {
   createRedisPresence(redisUrl: string): { shutdown(): Promise<void> | void };
   createRedisDriver(redisUrl: string): { shutdown(): Promise<void> | void };
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
-  registerAnalyticsRoutes(app: unknown, options?: { enableTestRoutes?: boolean }): void;
+  registerAnalyticsRoutes(app: unknown, options?: { enableTestRoutes?: boolean; store?: DevServerRoomSnapshotStore | null }): void;
   registerClientErrorRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
@@ -330,7 +330,16 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     createRedisPresence,
     createRedisDriver,
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
-    registerAnalyticsRoutes: (app, options) => registerAnalyticsRoutes(app as never, options),
+    registerAnalyticsRoutes: (app, options) => {
+      const routeOptions =
+        options === undefined
+          ? undefined
+          : {
+              ...(options.enableTestRoutes === undefined ? {} : { enableTestRoutes: options.enableTestRoutes }),
+              ...(options.store === undefined ? {} : { store: options.store as RoomSnapshotStore | null })
+            };
+      return registerAnalyticsRoutes(app as never, routeOptions);
+    },
     registerClientErrorRoutes: (app, store) => registerClientErrorRoutes(app as never, store as RoomSnapshotStore | null),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
@@ -494,7 +503,8 @@ export async function startDevServer(
   deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
   deps.registerAnalyticsRoutes(expressApp, {
-    enableTestRoutes: process.env.VEIL_ENABLE_TEST_ENDPOINTS === "1"
+    enableTestRoutes: process.env.VEIL_ENABLE_TEST_ENDPOINTS === "1",
+    store: effectiveSnapshotStore
   });
   deps.registerClientErrorRoutes(expressApp, effectiveSnapshotStore);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -8,9 +8,11 @@ import {
   registerAnalyticsRoutes,
   resetAnalyticsRuntimeDependencies
 } from "@server/domain/ops/analytics";
+import { issueGuestAuthSession, resetGuestAuthSessions } from "@server/domain/account/auth";
 
 afterEach(() => {
   resetAnalyticsRuntimeDependencies();
+  resetGuestAuthSessions();
 });
 
 interface TestResponse {
@@ -38,7 +40,7 @@ function createResponse(): TestResponse {
   };
 }
 
-function createRequest(method: string, body?: string): Readable & {
+function createRequest(method: string, body?: string, headers: Record<string, string> = {}): Readable & {
   method: string;
   headers: Record<string, string>;
   resume(): void;
@@ -49,7 +51,10 @@ function createRequest(method: string, body?: string): Readable & {
     resume(): void;
   };
   request.method = method;
-  request.headers = body == null ? {} : { "content-length": Buffer.byteLength(body).toString() };
+  request.headers = {
+    ...headers,
+    ...(body == null ? {} : { "content-length": Buffer.byteLength(body).toString() })
+  };
   request.resume = () => {
     request.read();
   };
@@ -129,9 +134,12 @@ test("registerAnalyticsRoutes accepts analytics batches and logs the payload whe
   const requestBody = JSON.stringify({
     schemaVersion: 1,
     emittedAt: "2026-04-05T00:00:00.000Z",
-    events: [{ name: "shop_open" }, { name: "battle_start" }]
+    events: [{ name: "shop_open", playerId: "spoofed-player" }, { name: "battle_start" }]
   });
-  const request = createRequest("POST", requestBody);
+  const session = issueGuestAuthSession({ playerId: "player-1", displayName: "Veil Ranger" });
+  const request = createRequest("POST", requestBody, {
+    authorization: `Bearer ${session.token}`
+  });
   const response = createResponse();
 
   let nextCalled = false;
@@ -143,7 +151,7 @@ test("registerAnalyticsRoutes accepts analytics batches and logs the payload whe
   await handler(request as never, response);
 
   assert.equal(response.statusCode, 202);
-  assert.equal(response.headers["Access-Control-Allow-Origin"], "*");
+  assert.equal(response.headers["Access-Control-Allow-Origin"], undefined);
   assert.equal(response.headers["Content-Type"], "application/json; charset=utf-8");
   assert.deepEqual(JSON.parse(response.body), { accepted: 2 });
   assert.equal(logs.length, 1);
@@ -154,8 +162,32 @@ test("registerAnalyticsRoutes accepts analytics batches and logs the payload whe
 
   assert.equal(getResponse.statusCode, 200);
   assert.deepEqual(JSON.parse(getResponse.body), {
-    events: [{ name: "shop_open" }, { name: "battle_start" }]
+    events: [{ name: "shop_open", playerId: "player-1" }, { name: "battle_start", playerId: "player-1" }]
   });
+});
+
+test("registerAnalyticsRoutes rejects public analytics ingest without an auth session", async () => {
+  let handler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+
+  registerAnalyticsRoutes({
+    use() {},
+    get() {},
+    post(_path, nextHandler) {
+      handler = nextHandler as never;
+    }
+  });
+
+  assert(handler);
+
+  const request = createRequest("POST", JSON.stringify({ events: [{ name: "session_start" }] }));
+  const response = createResponse();
+
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 401);
+  assert.match(response.body, /Analytics ingestion requires an authenticated player session/);
 });
 
 test("registerAnalyticsRoutes queues accepted events for the configured analytics sink", async () => {
@@ -207,7 +239,10 @@ test("registerAnalyticsRoutes queues accepted events for the configured analytic
       }
     ]
   });
-  const request = createRequest("POST", requestBody);
+  const session = issueGuestAuthSession({ playerId: "player-1", displayName: "Veil Ranger" });
+  const request = createRequest("POST", requestBody, {
+    authorization: `Bearer ${session.token}`
+  });
   const response = createResponse();
 
   try {
@@ -279,7 +314,10 @@ test("registerAnalyticsRoutes rejects malformed analytics payloads", async () =>
 
   assert(handler);
 
-  const request = createRequest("POST", "{");
+  const session = issueGuestAuthSession({ playerId: "player-1", displayName: "Veil Ranger" });
+  const request = createRequest("POST", "{", {
+    authorization: `Bearer ${session.token}`
+  });
   const response = createResponse();
 
   await handler(request as never, response);
@@ -287,4 +325,31 @@ test("registerAnalyticsRoutes rejects malformed analytics payloads", async () =>
   assert.equal(response.statusCode, 400);
   assert.equal(response.headers["Content-Type"], "application/json; charset=utf-8");
   assert.match(response.body, /"code":"SyntaxError"/);
+});
+
+test("registerAnalyticsRoutes rejects unknown analytics event names", async () => {
+  let handler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+
+  registerAnalyticsRoutes({
+    use() {},
+    get() {},
+    post(_path, nextHandler) {
+      handler = nextHandler as never;
+    }
+  });
+
+  assert(handler);
+
+  const session = issueGuestAuthSession({ playerId: "player-1", displayName: "Veil Ranger" });
+  const request = createRequest("POST", JSON.stringify({ events: [{ name: "fake_purchase_completed" }] }), {
+    authorization: `Bearer ${session.token}`
+  });
+  const response = createResponse();
+
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.match(response.body, /analytics event name is not allowed/);
 });

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -15,6 +15,7 @@ import {
   type RuntimePersistenceHealth,
   resetRuntimeObservability
 } from "@server/domain/ops/observability";
+import { issueGuestAuthSession, resetGuestAuthSessions } from "@server/domain/account/auth";
 
 const RUNTIME_ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN?.trim() || "runtime-admin-token";
 process.env.VEIL_ADMIN_TOKEN = RUNTIME_ADMIN_TOKEN;
@@ -25,6 +26,7 @@ async function wait(ms: number): Promise<void> {
 
 async function startObservabilityServer(port: number, persistence?: RuntimePersistenceHealth): Promise<Server> {
   configureRoomSnapshotStore(null);
+  resetGuestAuthSessions();
   resetLobbyRoomRegistry();
   resetAccountTokenDeliveryState();
   resetRuntimeObservability();
@@ -239,7 +241,8 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   const analyticsIngestResponse = await fetch(`http://127.0.0.1:${port}/api/analytics/events`, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${issueGuestAuthSession({ playerId: "player-1", displayName: "Veil Ranger" }).token}`
     },
     body: JSON.stringify({
       schemaVersion: 1,
@@ -327,9 +330,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPayload.runtime.gameplayTraffic.worldActionsTotal, 1);
   assert.equal(healthPayload.runtime.gameplayTraffic.battleActionsTotal, 0);
   assert.equal(healthPayload.runtime.gameplayTraffic.actionMessagesTotal, 1);
-  assert.equal(healthPayload.runtime.auth.activeGuestSessionCount, 0);
+  assert.equal(healthPayload.runtime.auth.activeGuestSessionCount, 1);
   assert.equal(healthPayload.runtime.auth.activeAccountSessionCount, 0);
-  assert.equal(healthPayload.runtime.auth.counters.sessionChecksTotal, 0);
+  assert.equal(healthPayload.runtime.auth.counters.sessionChecksTotal, 1);
   assert.equal(healthPayload.runtime.matchmaking.counters.rateLimitedTotal, 2);
   assert.equal(healthPayload.runtime.antiCheat.counters.alertsTotal, 0);
   assert.equal(healthPayload.runtime.antiCheat.alertsTracked, 0);
@@ -354,7 +357,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(readinessResponse.status, 200);
   assert.equal(readinessResponse.headers.get("access-control-allow-origin"), null);
   assert.equal(readinessPayload.status, "ok");
-  assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
+  assert.match(readinessPayload.headline, /guest=1 account=0 lockouts=0/);
 
   const featureFlagResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/feature-flags`, {
     headers: adminHeaders
@@ -498,9 +501,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_room_disposals_total 0$/m);
   assert.match(metricsText, /^veil_battle_completions_total 0$/m);
   assert.match(metricsText, /^veil_battle_aborts_total 0$/m);
-  assert.match(metricsText, /^veil_auth_guest_sessions 0$/m);
+  assert.match(metricsText, /^veil_auth_guest_sessions 1$/m);
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
-  assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
+  assert.match(metricsText, /^veil_auth_session_checks_total 1$/m);
   assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
   assert.match(metricsText, /^veil_matchmaking_queue_depth 7$/m);
   assert.match(metricsText, /^veil_anti_cheat_alerts_total 0$/m);

--- a/apps/server/test/wechat-payment-flow.test.ts
+++ b/apps/server/test/wechat-payment-flow.test.ts
@@ -246,7 +246,7 @@ test("wechat payment callback settles the order, emits purchase analytics, and d
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
   });
   const server = await startWechatPaymentServer({
     port,
@@ -337,7 +337,7 @@ test("wechat payment verify settles a created order and emits purchase analytics
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
   });
   const server = await startWechatPaymentServer({
     port,
@@ -399,7 +399,7 @@ test("wechat payment verify returns amount mismatch without granting rewards and
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
   });
   const server = await startWechatPaymentServer({
     port,
@@ -468,7 +468,7 @@ test("wechat payment verify emits purchase_failed when settlement cannot grant r
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
   });
   const originalCompletePaymentOrder = store.completePaymentOrder.bind(store);
   store.completePaymentOrder = async (orderId, input) => {


### PR DESCRIPTION
Closes #1679\n\nSummary:\n- require authenticated sessions for public analytics ingest\n- restrict analytics CORS and validate event names\n- keep /api/test/analytics/events test-only\n\nValidation:\n- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/analytics.test.ts apps/server/test/runtime-observability-routes.test.ts apps/server/test/wechat-payment-flow.test.ts\n- npm run typecheck -- server