### PR TITLE
fix: harden account password policy

### DIFF
--- a/apps/client/test/auth-privacy-consent.test.ts
+++ b/apps/client/test/auth-privacy-consent.test.ts
@@ -122,10 +122,10 @@ test("h5 auth helpers forward privacy consent and clear storage after deletion",
     await loginGuestAuthSession("guest-privacy", "隐私旅人", {
       privacyConsentAccepted: true
     });
-    await loginPasswordAuthSession("Veil-Ranger", "hunter2", {
+    await loginPasswordAuthSession("Veil-Ranger", "hunter22", {
       privacyConsentAccepted: true
     });
-    await confirmAccountRegistration("Veil-Ranger", "dev-registration-token", "hunter2", {
+    await confirmAccountRegistration("Veil-Ranger", "dev-registration-token", "hunter22", {
       privacyConsentAccepted: true
     });
     const deleted = await deleteCurrentPlayerAccount();

--- a/apps/client/test/auth-session-storage.test.ts
+++ b/apps/client/test/auth-session-storage.test.ts
@@ -256,7 +256,7 @@ test("account registration helpers request a dev token and persist the confirmed
     const requestResult = await requestAccountRegistration("Veil-Ranger", "暮潮守望");
     assert.equal(requestResult.registrationToken, "dev-registration-token");
 
-    const session = await confirmAccountRegistration("Veil-Ranger", "dev-registration-token", "hunter2");
+    const session = await confirmAccountRegistration("Veil-Ranger", "dev-registration-token", "hunter22");
     assert.equal(session.loginId, "veil-ranger");
     assert.equal(session.token, "account.token");
     assert.match(requests[0]?.url ?? "", /\/api\/auth\/account-registration\/request$/);
@@ -330,7 +330,7 @@ test("password recovery helpers request a dev token and confirm reset without mu
     const requestResult = await requestPasswordRecovery("Veil-Ranger");
     assert.equal(requestResult.recoveryToken, "dev-recovery-token");
 
-    await confirmPasswordRecovery("Veil-Ranger", "dev-recovery-token", "hunter3");
+    await confirmPasswordRecovery("Veil-Ranger", "dev-recovery-token", "hunter33");
     assert.match(requests[0]?.url ?? "", /\/api\/auth\/password-recovery\/request$/);
     assert.match(requests[1]?.url ?? "", /\/api\/auth\/password-recovery\/confirm$/);
     assert.equal(values.size, 0);

--- a/apps/cocos-client/test/cocos-account-lifecycle.test.ts
+++ b/apps/cocos-client/test/cocos-account-lifecycle.test.ts
@@ -11,7 +11,7 @@ test("buildCocosAccountLifecyclePanelView exposes registration dev-token guidanc
     loginId: "veil-ranger",
     displayName: "暮潮守望",
     token: "dev-registration-token",
-    password: "hunter2",
+    password: "hunter22",
     deliveryMode: "dev-token",
     expiresAt: "2026-03-29T05:51:00.000Z"
   });
@@ -69,7 +69,7 @@ test("buildCocosAccountLifecycleReadinessView reports blocked external token del
     loginId: "veil-ranger",
     displayName: "",
     token: "",
-    password: "hunter2",
+    password: "hunter22",
     deliveryMode: "external",
     expiresAt: "2026-03-29T06:00:00.000Z"
   });

--- a/apps/cocos-client/test/cocos-account-registration.test.ts
+++ b/apps/cocos-client/test/cocos-account-registration.test.ts
@@ -40,7 +40,7 @@ test("buildCocosAccountRegistrationPanelView surfaces validation errors for malf
     draft: createDraft({
       loginId: "BAD ID",
       token: "dev-registration-token",
-      password: "hunter2"
+      password: "hunter22"
     }),
     privacyConsentAccepted: true,
     showValidationErrors: true,
@@ -63,7 +63,7 @@ test("buildCocosAccountRegistrationPanelView disables submission actions while w
       loginId: "veil-ranger",
       displayName: "暮潮守望",
       token: "dev-registration-token",
-      password: "hunter2",
+      password: "hunter22",
       deliveryMode: "dev-token"
     }),
     privacyConsentAccepted: true,
@@ -94,7 +94,7 @@ test("buildCocosAccountRegistrationPanelView exposes bound identities after regi
       loginId: "veil-ranger",
       displayName: "暮潮守望",
       token: "dev-registration-token",
-      password: "hunter2",
+      password: "hunter22",
       deliveryMode: "dev-token"
     }),
     privacyConsentAccepted: true,

--- a/apps/cocos-client/test/cocos-auth-privacy-consent.test.ts
+++ b/apps/cocos-client/test/cocos-auth-privacy-consent.test.ts
@@ -66,11 +66,11 @@ test("cocos auth helpers forward privacy consent across guest, account, registra
     fetchImpl,
     privacyConsentAccepted: true
   });
-  await loginCocosPasswordAuthSession("http://127.0.0.1:2567", "Veil-Ranger", "hunter2", {
+  await loginCocosPasswordAuthSession("http://127.0.0.1:2567", "Veil-Ranger", "hunter22", {
     fetchImpl,
     privacyConsentAccepted: true
   });
-  await confirmCocosAccountRegistration("http://127.0.0.1:2567", "Veil-Ranger", "dev-registration-token", "hunter2", {
+  await confirmCocosAccountRegistration("http://127.0.0.1:2567", "Veil-Ranger", "dev-registration-token", "hunter22", {
     fetchImpl,
     privacyConsentAccepted: true
   });

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -378,7 +378,7 @@ test("loginCocosPasswordAuthSession stores account sessions with loginId", async
     }
   };
 
-  const session = await loginCocosPasswordAuthSession("http://127.0.0.1:2567", "Veil-Ranger", "hunter2", {
+  const session = await loginCocosPasswordAuthSession("http://127.0.0.1:2567", "Veil-Ranger", "hunter22", {
     storage,
     fetchImpl: async () =>
       new Response(
@@ -467,7 +467,7 @@ test("cocos account registration helpers request a dev token and persist the con
     "http://127.0.0.1:2567",
     "Veil-Ranger",
     "dev-registration-token",
-    "hunter2",
+    "hunter22",
     { fetchImpl, storage }
   );
   assert.equal(session.loginId, "veil-ranger");
@@ -508,7 +508,7 @@ test("cocos password recovery helpers request a dev token and confirm reset", as
   });
   assert.equal(requestResult.recoveryToken, "dev-recovery-token");
 
-  await confirmCocosPasswordRecovery("http://127.0.0.1:2567", "Veil-Ranger", "dev-recovery-token", "hunter3", {
+  await confirmCocosPasswordRecovery("http://127.0.0.1:2567", "Veil-Ranger", "dev-recovery-token", "hunter33", {
     fetchImpl
   });
   assert.match(requests[0]?.url ?? "", /\/api\/auth\/password-recovery\/request$/);

--- a/apps/server/src/domain/account/auth.ts
+++ b/apps/server/src/domain/account/auth.ts
@@ -167,7 +167,32 @@ interface AccountRegistrationState {
   expiresAt: string;
 }
 
-const MIN_ACCOUNT_PASSWORD_LENGTH = 6;
+const MIN_ACCOUNT_PASSWORD_LENGTH = 8;
+const MAX_ACCOUNT_PASSWORD_LENGTH = 128;
+const COMMON_WEAK_ACCOUNT_PASSWORDS = new Set([
+  "123456",
+  "1234567",
+  "12345678",
+  "123456789",
+  "1234567890",
+  "111111",
+  "000000",
+  "password",
+  "password1",
+  "password12",
+  "password123",
+  "qwerty",
+  "qwerty123",
+  "admin",
+  "admin123",
+  "letmein",
+  "letmein1",
+  "welcome",
+  "welcome1",
+  "iloveyou",
+  "abc123",
+  "hunter2"
+]);
 const DEFAULT_RATE_LIMIT_AUTH_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_AUTH_MAX = 10;
 const DEFAULT_AUTH_LOCKOUT_THRESHOLD = 10;
@@ -676,6 +701,15 @@ function normalizeAccountPassword(password?: string | null): string {
   const normalized = password.trim();
   if (normalized.length < MIN_ACCOUNT_PASSWORD_LENGTH) {
     throw new Error(`password must be at least ${MIN_ACCOUNT_PASSWORD_LENGTH} characters`);
+  }
+  if (normalized.length > MAX_ACCOUNT_PASSWORD_LENGTH) {
+    throw new Error(`password must be at most ${MAX_ACCOUNT_PASSWORD_LENGTH} characters`);
+  }
+  if (!/[A-Za-z]/.test(normalized) || !/\d/.test(normalized)) {
+    throw new Error("password must include at least one letter and one number");
+  }
+  if (COMMON_WEAK_ACCOUNT_PASSWORDS.has(normalized.toLowerCase())) {
+    throw new Error("password is too common");
   }
 
   return normalized;

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -1340,7 +1340,7 @@ test("account bind upgrades a guest session into password login and account-logi
     },
     body: JSON.stringify({
       loginId: "veil-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1362,7 +1362,7 @@ test("account bind upgrades a guest session into password login and account-logi
     },
     body: JSON.stringify({
       loginId: "veil-ranger",
-      password: "hunter2"
+      password: "hunter22"
     })
   });
   const accountLoginPayload = (await accountLoginResponse.json()) as {
@@ -1389,6 +1389,64 @@ test("account bind upgrades a guest session into password login and account-logi
   assert.equal(sessionPayload.session.loginId, "veil-ranger");
 });
 
+test("account password policy rejects common and overlong passwords before hashing", async (t) => {
+  const port = 45580 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const guestLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "password-policy-player",
+      displayName: "密码守望",
+      privacyConsentAccepted: true
+    })
+  });
+  const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
+
+  const commonPasswordResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-bind`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      loginId: "policy-ranger",
+      password: "password123",
+      privacyConsentAccepted: true
+    })
+  });
+  const commonPasswordPayload = (await commonPasswordResponse.json()) as { error: { message: string } };
+
+  assert.equal(commonPasswordResponse.status, 400);
+  assert.match(commonPasswordPayload.error.message, /too common/i);
+
+  const overlongPasswordResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-bind`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      loginId: "policy-ranger",
+      password: `A1${"x".repeat(127)}`,
+      privacyConsentAccepted: true
+    })
+  });
+  const overlongPasswordPayload = (await overlongPasswordResponse.json()) as { error: { message: string } };
+
+  assert.equal(overlongPasswordResponse.status, 400);
+  assert.match(overlongPasswordPayload.error.message, /at most 128 characters/i);
+});
+
 test("account-login carries the streak from yesterday and returns the issued reward", async (t) => {
   const port = 44505 + Math.floor(Math.random() * 1000);
   const store = new MemoryAuthStore();
@@ -1402,7 +1460,7 @@ test("account-login carries the streak from yesterday and returns the issued rew
   });
   await store.bindPlayerAccountCredentials("daily-account", {
     loginId: "daily-account",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   await store.savePlayerAccountProgress("daily-account", {
     gems: 20,
@@ -1424,7 +1482,7 @@ test("account-login carries the streak from yesterday and returns the issued rew
     },
     body: JSON.stringify({
       loginId: "daily-account",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1504,7 +1562,7 @@ test("account bind emits experiment conversion analytics for the assigned varian
     },
     body: JSON.stringify({
       loginId: "veil-experiment",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1533,7 +1591,7 @@ test("account access tokens expire with token_expired and can be rotated through
   const store = new MemoryAuthStore();
   await store.bindPlayerAccountCredentials("expiry-player", {
     loginId: "expiry-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   const server = await startAuthServer(port, store);
 
@@ -1550,7 +1608,7 @@ test("account access tokens expire with token_expired and can be rotated through
     },
     body: JSON.stringify({
       loginId: "expiry-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1591,7 +1649,7 @@ test("refresh rotation invalidates the previous refresh token and logout revokes
   const store = new MemoryAuthStore();
   await store.bindPlayerAccountCredentials("rotate-player", {
     loginId: "rotate-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   const server = await startAuthServer(port, store);
 
@@ -1607,7 +1665,7 @@ test("refresh rotation invalidates the previous refresh token and logout revokes
     },
     body: JSON.stringify({
       loginId: "rotate-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1659,7 +1717,7 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
   const store = new MemoryAuthStore();
   await store.bindPlayerAccountCredentials("metrics-player", {
     loginId: "metrics-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   const server = await startAuthServer(port, store);
 
@@ -1691,7 +1749,7 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
     },
     body: JSON.stringify({
       loginId: "metrics-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1722,7 +1780,7 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
     },
     body: JSON.stringify({
       loginId: "metrics-ranger",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     })
   });
@@ -1807,7 +1865,7 @@ test("revoking one device session leaves other account sessions active and block
   const store = new MemoryAuthStore();
   await store.bindPlayerAccountCredentials("device-player", {
     loginId: "device-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   const server = await startAuthServer(port, store);
 
@@ -1824,7 +1882,7 @@ test("revoking one device session leaves other account sessions active and block
     },
     body: JSON.stringify({
       loginId: "device-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1838,7 +1896,7 @@ test("revoking one device session leaves other account sessions active and block
     },
     body: JSON.stringify({
       loginId: "device-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1885,7 +1943,7 @@ test("password changes revoke the current account session family", async (t) => 
   const store = new MemoryAuthStore();
   await store.bindPlayerAccountCredentials("password-player", {
     loginId: "password-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   const server = await startAuthServer(port, store);
 
@@ -1901,7 +1959,7 @@ test("password changes revoke the current account session family", async (t) => 
     },
     body: JSON.stringify({
       loginId: "password-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -1914,8 +1972,8 @@ test("password changes revoke the current account session family", async (t) => 
       Authorization: `Bearer ${loginPayload.session.token}`
     },
     body: JSON.stringify({
-      currentPassword: "hunter2",
-      newPassword: "hunter3"
+      currentPassword: "hunter22",
+      newPassword: "hunter33"
     })
   });
 
@@ -2016,7 +2074,7 @@ test(
   });
   await store.bindPlayerAccountCredentials("lockout-player", {
     loginId: "lockout-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2033,7 +2091,7 @@ test(
       },
       body: JSON.stringify({
         loginId: "lockout-ranger",
-        password: "wrong-password",
+        password: "wrong-password1",
         privacyConsentAccepted: true
       })
     });
@@ -2050,7 +2108,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "lockout-ranger",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     })
   });
@@ -2082,7 +2140,7 @@ test("account login lockout expires after the configured duration", { concurrenc
   });
   await store.bindPlayerAccountCredentials("lockout-expiry-player", {
     loginId: "expiry-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2099,7 +2157,7 @@ test("account login lockout expires after the configured duration", { concurrenc
       },
       body: JSON.stringify({
         loginId: "expiry-ranger",
-        password: "wrong-password",
+        password: "wrong-password1",
         privacyConsentAccepted: true
       })
     });
@@ -2114,7 +2172,7 @@ test("account login lockout expires after the configured duration", { concurrenc
     },
     body: JSON.stringify({
       loginId: "expiry-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2151,7 +2209,7 @@ test(
   });
   await store.bindPlayerAccountCredentials("credential-stuffing-player", {
     loginId: "credential-stuffing-real",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2167,7 +2225,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "credential-stuffing-a",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     })
   });
@@ -2182,7 +2240,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "credential-stuffing-b",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     })
   });
@@ -2197,7 +2255,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "credential-stuffing-real",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     })
   });
@@ -2216,7 +2274,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "credential-stuffing-real",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2265,7 +2323,7 @@ test(
     },
     body: JSON.stringify({
       loginId: "credential-stuffing-real",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2367,7 +2425,7 @@ test("account registration request and confirm create a new formal account, sess
     body: JSON.stringify({
       loginId: "formal-ranger",
       registrationToken: requestPayload.registrationToken,
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2397,7 +2455,7 @@ test("account registration request and confirm create a new formal account, sess
     },
     body: JSON.stringify({
       loginId: "formal-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2415,7 +2473,7 @@ test("account registration request rejects already-bound login IDs", { concurren
   });
   await store.bindPlayerAccountCredentials("registration-conflict-player", {
     loginId: "taken-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2469,7 +2527,7 @@ test("account registration confirm rejects invalid tokens", { concurrency: false
     body: JSON.stringify({
       loginId: "invalid-registration-ranger",
       registrationToken: "wrong-token",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2536,7 +2594,7 @@ test("account registration request reuses the active token for the same loginId 
     body: JSON.stringify({
       loginId: "stable-registration-ranger",
       registrationToken: firstPayload.registrationToken,
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2606,7 +2664,7 @@ test("password recovery request and confirm reset the password, revoke old sessi
   });
   await store.bindPlayerAccountCredentials("recovery-player", {
     loginId: "recovery-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2621,7 +2679,7 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2656,7 +2714,7 @@ test("password recovery request and confirm reset the password, revoke old sessi
     body: JSON.stringify({
       loginId: "recovery-ranger",
       recoveryToken: requestPayload.recoveryToken,
-      newPassword: "hunter3"
+      newPassword: "hunter33"
     })
   });
   const confirmPayload = (await confirmResponse.json()) as { account: PlayerAccountSnapshot };
@@ -2680,7 +2738,7 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -2693,17 +2751,17 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter3",
+      password: "hunter33",
       privacyConsentAccepted: true
     })
   });
   assert.equal(freshPasswordResponse.status, 200);
 
   const account = await store.loadPlayerAccount("recovery-player");
-  assert.equal(account?.recentEventLog[0]?.category, "account");
-  assert.match(account?.recentEventLog[0]?.description ?? "", /重置口令/);
-  assert.equal(account?.recentEventLog[1]?.category, "account");
-  assert.match(account?.recentEventLog[1]?.description ?? "", /发起密码找回申请/);
+  const accountEventDescriptions =
+    account?.recentEventLog.filter((entry) => entry.category === "account").map((entry) => entry.description) ?? [];
+  assert.ok(accountEventDescriptions.some((description) => /重置口令/.test(description)));
+  assert.ok(accountEventDescriptions.some((description) => /发起密码找回申请/.test(description)));
 });
 
 test("password recovery confirm rejects invalid tokens", { concurrency: false }, async (t) => {
@@ -2717,7 +2775,7 @@ test("password recovery confirm rejects invalid tokens", { concurrency: false },
   });
   await store.bindPlayerAccountCredentials("recovery-invalid-player", {
     loginId: "invalid-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2744,7 +2802,7 @@ test("password recovery confirm rejects invalid tokens", { concurrency: false },
     body: JSON.stringify({
       loginId: "invalid-ranger",
       recoveryToken: "wrong-token",
-      newPassword: "hunter3"
+      newPassword: "hunter33"
     })
   });
   const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };
@@ -2764,7 +2822,7 @@ test("password recovery request reuses the active token and avoids duplicate aud
   });
   await store.bindPlayerAccountCredentials("recovery-stable-player", {
     loginId: "stable-recovery-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2820,7 +2878,7 @@ test("password recovery request reuses the active token and avoids duplicate aud
     body: JSON.stringify({
       loginId: "stable-recovery-ranger",
       recoveryToken: firstPayload.recoveryToken,
-      newPassword: "hunter3"
+      newPassword: "hunter33"
     })
   });
 
@@ -2847,7 +2905,7 @@ test("password recovery request returns 429 after the per-IP rate limit is excee
   });
   await store.bindPlayerAccountCredentials("recovery-rate-limit-player", {
     loginId: "limit-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -2964,7 +3022,7 @@ test("account registration request uses webhook delivery without leaking the tok
     body: JSON.stringify({
       loginId: "webhook-registration-ranger",
       registrationToken: webhook.requests[0]?.body.token,
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -3034,7 +3092,7 @@ test("account registration request uses smtp delivery without leaking the token"
     body: JSON.stringify({
       loginId: "smtp-registration-ranger",
       registrationToken: tokenMatch?.[1],
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     })
   });
@@ -3153,7 +3211,7 @@ test("password recovery request uses webhook delivery without leaking the token"
   });
   await store.bindPlayerAccountCredentials("webhook-recovery-player", {
     loginId: "webhook-recovery-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -3219,7 +3277,7 @@ test("password recovery request uses webhook delivery without leaking the token"
     body: JSON.stringify({
       loginId: "webhook-recovery-ranger",
       recoveryToken: webhook.requests[0]?.body.token,
-      newPassword: "hunter3"
+      newPassword: "hunter33"
     })
   });
 
@@ -3250,7 +3308,7 @@ test("password recovery request schedules retry for retryable webhook failures a
   });
   await store.bindPlayerAccountCredentials("failed-recovery-player", {
     loginId: "failed-recovery-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -3373,7 +3431,7 @@ test("password recovery request returns 502 and dead-letters non-retryable webho
   });
   await store.bindPlayerAccountCredentials("dead-letter-recovery-player", {
     loginId: "dead-letter-recovery-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
 
   t.after(async () => {
@@ -4294,7 +4352,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
   });
   await store.bindPlayerAccountCredentials("banned-player", {
     loginId: "banned-ranger",
-    passwordHash: hashAccountPassword("secret-pass")
+    passwordHash: hashAccountPassword("secret-pass1")
   });
   const server = await startAuthServer(port, store);
 
@@ -4310,7 +4368,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
     },
     body: JSON.stringify({
       loginId: "banned-ranger",
-      password: "secret-pass",
+      password: "secret-pass1",
       privacyConsentAccepted: true
     })
   });
@@ -4343,7 +4401,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
     },
     body: JSON.stringify({
       loginId: "banned-ranger",
-      password: "secret-pass",
+      password: "secret-pass1",
       privacyConsentAccepted: true
     })
   });
@@ -4458,7 +4516,7 @@ test("account registration confirmation requires privacy consent", async (t) => 
     body: JSON.stringify({
       loginId: "consent-ranger",
       registrationToken: requestPayload.registrationToken,
-      password: "hunter2"
+      password: "hunter22"
     })
   });
   const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };

--- a/apps/server/test/auth-rate-limiting.test.ts
+++ b/apps/server/test/auth-rate-limiting.test.ts
@@ -502,7 +502,7 @@ test("real dev-server locks an account after 10 failed attempts and rejects atte
     playerId: "rate-limit-brute-force-player",
     displayName: "Rate Limit Ranger",
     loginId: "rate-limit-ranger",
-    password: "hunter2"
+    password: "hunter22"
   });
   const { app, runtime } = await startRateLimitDevServer(store);
 
@@ -517,7 +517,7 @@ test("real dev-server locks an account after 10 failed attempts and rejects atte
       path: "/api/auth/account-login",
       body: {
         loginId: "rate-limit-ranger",
-        password: "wrong-password",
+        password: "wrong-password1",
         privacyConsentAccepted: true
       }
     });
@@ -533,7 +533,7 @@ test("real dev-server locks an account after 10 failed attempts and rejects atte
     path: "/api/auth/account-login",
     body: {
       loginId: "rate-limit-ranger",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     }
   });
@@ -562,7 +562,7 @@ test("real dev-server blocks credential stuffing from one IP after five distinct
     playerId: "credential-stuffing-player",
     displayName: "Credential Stuffing Ranger",
     loginId: "credential-stuffing-real",
-    password: "hunter2"
+    password: "hunter22"
   });
   const { app, runtime } = await startRateLimitDevServer(store);
 
@@ -582,7 +582,7 @@ test("real dev-server blocks credential stuffing from one IP after five distinct
       },
       body: {
         loginId: `credential-burst-${index}`,
-        password: "wrong-password",
+        password: "wrong-password1",
         privacyConsentAccepted: true
       }
     });
@@ -602,7 +602,7 @@ test("real dev-server blocks credential stuffing from one IP after five distinct
     },
     body: {
       loginId: "credential-burst-6",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     }
   });
@@ -631,7 +631,7 @@ test("real dev-server clears account lockout state after the configured recovery
     playerId: "rate-limit-recovery-player",
     displayName: "Recovery Ranger",
     loginId: "recovery-ranger",
-    password: "hunter2"
+    password: "hunter22"
   });
   const { app, runtime } = await startRateLimitDevServer(store);
 
@@ -646,7 +646,7 @@ test("real dev-server clears account lockout state after the configured recovery
       path: "/api/auth/account-login",
       body: {
         loginId: "recovery-ranger",
-        password: "wrong-password",
+        password: "wrong-password1",
         privacyConsentAccepted: true
       }
     });
@@ -658,7 +658,7 @@ test("real dev-server clears account lockout state after the configured recovery
     path: "/api/auth/account-login",
     body: {
       loginId: "recovery-ranger",
-      password: "wrong-password",
+      password: "wrong-password1",
       privacyConsentAccepted: true
     }
   });
@@ -673,7 +673,7 @@ test("real dev-server clears account lockout state after the configured recovery
     path: "/api/auth/account-login",
     body: {
       loginId: "recovery-ranger",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     }
   });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -3214,7 +3214,7 @@ test("player account password changes revoke the current access session family",
   });
   await store.bindPlayerAccountCredentials("password-player", {
     loginId: "veil-ranger",
-    passwordHash: hashAccountPassword("hunter2")
+    passwordHash: hashAccountPassword("hunter22")
   });
   await store.savePlayerAccountAuthSession("password-player", {
     refreshSessionId: "session-password",
@@ -3243,8 +3243,8 @@ test("player account password changes revoke the current access session family",
       Authorization: `Bearer ${session.token}`
     },
     body: JSON.stringify({
-      currentPassword: "hunter2",
-      newPassword: "hunter3"
+      currentPassword: "hunter22",
+      newPassword: "hunter33"
     })
   });
   const updatePayload = (await updateResponse.json()) as { account: PlayerAccountSnapshot };

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -121,7 +121,7 @@
 {
   "loginId": "veil-ranger",
   "registrationToken": "dev-token-example",
-  "password": "hunter2"
+  "password": "hunter22"
 }
 ```
 

--- a/packages/shared/test/auth-ui.test.ts
+++ b/packages/shared/test/auth-ui.test.ts
@@ -23,7 +23,7 @@ test("auth ui helper validates confirm drafts for registration and recovery", ()
     validateAccountLifecycleConfirm("registration", {
       loginId: "veil-ranger",
       token: "",
-      password: "hunter2"
+      password: "hunter22"
     }),
     {
       field: "token",
@@ -48,7 +48,7 @@ test("auth ui helper validates confirm drafts for registration and recovery", ()
     validateAccountLifecycleConfirm("registration", {
       loginId: "veil-ranger",
       token: "dev-registration-token",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: true
     }),
     null
@@ -58,7 +58,7 @@ test("auth ui helper validates confirm drafts for registration and recovery", ()
     validateAccountLifecycleConfirm("registration", {
       loginId: "veil-ranger",
       token: "dev-registration-token",
-      password: "hunter2",
+      password: "hunter22",
       privacyConsentAccepted: false
     }),
     {


### PR DESCRIPTION
Closes #1682\n\nSummary:\n- raise account password minimum to 8, cap maximum at 128\n- require letters and digits and reject common weak passwords\n- refresh account auth tests and docs for the stronger policy\n\nValidation:\n- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/auth-guest-login.test.ts apps/server/test/auth-rate-limiting.test.ts apps/server/test/player-account-routes.test.ts apps/client/test/auth-privacy-consent.test.ts apps/client/test/auth-session-storage.test.ts apps/cocos-client/test/cocos-auth-privacy-consent.test.ts apps/cocos-client/test/cocos-lobby.test.ts apps/cocos-client/test/cocos-account-lifecycle.test.ts apps/cocos-client/test/cocos-account-registration.test.ts packages/shared/test/auth-ui.test.ts\n- npm run typecheck -- server