### PR TITLE
fix: add launch security headers

### DIFF
--- a/k8s/canary/ingress-canary.yaml
+++ b/k8s/canary/ingress-canary.yaml
@@ -5,6 +5,13 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/canary: "true"
     nginx.ingress.kubernetes.io/canary-weight: "10"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
+      more_set_headers "Content-Security-Policy: default-src 'self'; connect-src 'self' https://*.sentry.io wss://game.projectveil.prod; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
+      more_set_headers "X-Frame-Options: DENY";
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+      more_set_headers "Permissions-Policy: camera=(), geolocation=(), microphone=()";
 spec:
   ingressClassName: nginx
   rules:

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -7,6 +7,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
+      more_set_headers "Content-Security-Policy: default-src 'self'; connect-src 'self' https://*.sentry.io wss://game.projectveil.prod; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
+      more_set_headers "X-Frame-Options: DENY";
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+      more_set_headers "Permissions-Policy: camera=(), geolocation=(), microphone=()";
 spec:
   ingressClassName: nginx
   tls:

--- a/scripts/test/k8s-runtime-hardening.test.ts
+++ b/scripts/test/k8s-runtime-hardening.test.ts
@@ -88,6 +88,25 @@ test("network policy restricts ingress to ingress-nginx and narrows egress", asy
   }
 });
 
+test("ingresses inject baseline browser security response headers", async () => {
+  const [primaryIngress, canaryIngress] = await Promise.all([
+    readRepoFile("k8s/ingress.yaml"),
+    readRepoFile("k8s/canary/ingress-canary.yaml")
+  ]);
+
+  for (const ingress of [primaryIngress, canaryIngress]) {
+    assert.match(ingress, /nginx\.ingress\.kubernetes\.io\/configuration-snippet:\s*\|/);
+    assert.match(ingress, /Strict-Transport-Security: max-age=31536000; includeSubDomains; preload/);
+    assert.match(ingress, /Content-Security-Policy: default-src 'self'/);
+    assert.match(ingress, /connect-src 'self' https:\/\/\*\.sentry\.io wss:\/\/game\.projectveil\.prod/);
+    assert.match(ingress, /frame-ancestors 'none'/);
+    assert.match(ingress, /X-Frame-Options: DENY/);
+    assert.match(ingress, /X-Content-Type-Options: nosniff/);
+    assert.match(ingress, /Referrer-Policy: strict-origin-when-cross-origin/);
+    assert.match(ingress, /Permissions-Policy: camera=\(\), geolocation=\(\), microphone=\(\)/);
+  }
+});
+
 test("production runbook and secrets inventory document compose MYSQL_ROOT_PASSWORD requirements", async () => {
   const [runbook, secretsInventory] = await Promise.all([
     readRepoFile("docs/ops/production-deploy-runbook.md"),


### PR DESCRIPTION
Closes #1681\n\nSummary:\n- add HSTS, CSP, frame, content-type, referrer, and permissions policy headers to ingress manifests\n- cover stable and canary ingress annotations in runtime hardening tests\n\nValidation:\n- node --import ./node_modules/tsx/dist/loader.mjs --test scripts/test/k8s-runtime-hardening.test.ts