### PR TITLE
fix: cap referral reward farming

### DIFF
--- a/apps/server/src/domain/account/player-accounts.ts
+++ b/apps/server/src/domain/account/player-accounts.ts
@@ -2869,6 +2869,24 @@ export function registerPlayerAccountRoutes(
         });
         return;
       }
+      if (error instanceof Error && error.message === "referral_daily_limit_exceeded") {
+        sendJson(response, 429, {
+          error: {
+            code: "referral_daily_limit_exceeded",
+            message: "Daily referral reward limit reached for this referrer"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "referral_lifetime_limit_exceeded") {
+        sendJson(response, 429, {
+          error: {
+            code: "referral_lifetime_limit_exceeded",
+            message: "Lifetime referral reward limit reached for this referrer"
+          }
+        });
+        return;
+      }
       if (error instanceof PayloadTooLargeError) {
         sendJson(response, 413, {
           error: {

--- a/apps/server/src/persistence/mysql/store.ts
+++ b/apps/server/src/persistence/mysql/store.ts
@@ -1285,6 +1285,9 @@ export {
   MAX_PLAYER_LOGIN_ID_LENGTH
 } from "@server/persistence/defaults";
 
+const DEFAULT_PLAYER_REFERRAL_DAILY_LIMIT = 5;
+const DEFAULT_PLAYER_REFERRAL_LIFETIME_LIMIT = 50;
+
 function timestampOf(value: Date | string): number {
   return (typeof value === "string" ? new Date(value) : value).getTime();
 }
@@ -7449,6 +7452,29 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          FOR UPDATE`,
         [normalizedReferrerId, normalizedNewPlayerId]
       );
+
+      const [referralLimitRows] = await connection.query<RowDataPacket[]>(
+        `SELECT
+           COUNT(*) AS lifetime_count,
+           SUM(CASE WHEN created_at >= UTC_DATE() THEN 1 ELSE 0 END) AS daily_count
+         FROM \`${MYSQL_PLAYER_REFERRAL_TABLE}\`
+         WHERE referrer_id = ?`,
+        [normalizedReferrerId]
+      );
+      const referralLimitRow = referralLimitRows[0] as
+        | {
+            lifetime_count?: unknown;
+            daily_count?: unknown;
+          }
+        | undefined;
+      const lifetimeCount = Number(referralLimitRow?.lifetime_count ?? 0);
+      const dailyCount = Number(referralLimitRow?.daily_count ?? 0);
+      if (dailyCount >= DEFAULT_PLAYER_REFERRAL_DAILY_LIMIT) {
+        throw new Error("referral_daily_limit_exceeded");
+      }
+      if (lifetimeCount >= DEFAULT_PLAYER_REFERRAL_LIFETIME_LIMIT) {
+        throw new Error("referral_lifetime_limit_exceeded");
+      }
 
       const referralId = randomUUID();
       try {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -137,6 +137,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     updatedAt: string;
   }>>();
   private readonly referrals = new Set<string>();
+  private readonly referralCountsByReferrer = new Map<string, number>();
   private nextNameHistoryId = 1;
   private nextSupportTicketId = 1;
 
@@ -403,10 +404,15 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     if (this.referrals.has(referralKey)) {
       throw new Error("duplicate_referral");
     }
+    const currentReferralCount = this.referralCountsByReferrer.get(normalizedReferrerId) ?? 0;
+    if (currentReferralCount >= 5) {
+      throw new Error("referral_daily_limit_exceeded");
+    }
 
     const referrer = await this.ensurePlayerAccount({ playerId: normalizedReferrerId });
     const newPlayer = await this.ensurePlayerAccount({ playerId: normalizedNewPlayerId });
     this.referrals.add(referralKey);
+    this.referralCountsByReferrer.set(normalizedReferrerId, currentReferralCount + 1);
 
     this.accounts.set(normalizedReferrerId, {
       ...referrer,
@@ -4568,6 +4574,68 @@ test("referral endpoint credits both accounts exactly once", async (t) => {
   const newPlayer = await store.loadPlayerAccount("new-player-2");
   assert.equal(referrer?.gems, 31);
   assert.equal(newPlayer?.gems, 23);
+});
+
+test("referral endpoint caps same-referrer reward farming", async (t) => {
+  const port = 44970 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "referrer-limit",
+    displayName: "推荐守门人"
+  });
+  const server = await startAccountRouteServer(port, store);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (let index = 0; index < 5; index += 1) {
+    const playerId = `new-player-limit-${index}`;
+    await store.ensurePlayerAccount({
+      playerId,
+      displayName: `新玩家 ${index}`
+    });
+    const session = issueGuestAuthSession({
+      playerId,
+      displayName: `新玩家 ${index}`
+    });
+    const response = await fetch(`http://127.0.0.1:${port}/api/player/referral`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        referrerId: "referrer-limit"
+      })
+    });
+    assert.equal(response.status, 200);
+  }
+
+  await store.ensurePlayerAccount({
+    playerId: "new-player-limit-5",
+    displayName: "第六位新玩家"
+  });
+  const blockedSession = issueGuestAuthSession({
+    playerId: "new-player-limit-5",
+    displayName: "第六位新玩家"
+  });
+  const blockedResponse = await fetch(`http://127.0.0.1:${port}/api/player/referral`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${blockedSession.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      referrerId: "referrer-limit"
+    })
+  });
+  const blockedPayload = (await blockedResponse.json()) as {
+    error: { code: string };
+  };
+
+  assert.equal(blockedResponse.status, 429);
+  assert.equal(blockedPayload.error.code, "referral_daily_limit_exceeded");
 });
 
 test("campaign mission completion unlocks the next chapter 1 mission and grants rewards", async (t) => {


### PR DESCRIPTION
Closes #1685

Summary:
- Add daily and lifetime same-referrer caps before awarding referral rewards.
- Return explicit 429 referral limit errors from the player referral route.
- Add route-level coverage for same-referrer reward-farming prevention.

Validation:
- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/player-account-routes.test.ts
- npm run typecheck -- server