### PR TITLE
fix: protect test analytics routes

### DIFF
--- a/apps/server/src/domain/ops/analytics.ts
+++ b/apps/server/src/domain/ops/analytics.ts
@@ -1,6 +1,8 @@
 import { ANALYTICS_EVENT_CATALOG, type AnalyticsEvent, type AnalyticsEventName, createAnalyticsEvent } from "@veil/shared/platform";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
+import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
+import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import type { RoomSnapshotStore } from "@server/persistence";
 
 const ANALYTICS_BUFFER_FLUSH_SIZE = 20;
@@ -188,7 +190,7 @@ function applyAnalyticsCors(
     response.setHeader("Vary", "Origin");
   }
   response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-  response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth, X-Veil-Admin-Token");
 }
 
 function sendUnauthorized(response: ServerResponse, code = "unauthorized"): void {
@@ -198,6 +200,68 @@ function sendUnauthorized(response: ServerResponse, code = "unauthorized"): void
       message: "Analytics ingestion requires an authenticated player session"
     }
   });
+}
+
+function sendAdminTokenNotConfigured(response: ServerResponse): void {
+  sendJson(response, 503, {
+    error: {
+      code: "admin_token_not_configured",
+      message: "VEIL_ADMIN_TOKEN is not configured"
+    }
+  });
+}
+
+function sendInvalidAdminToken(response: ServerResponse): void {
+  sendJson(response, 403, {
+    error: {
+      code: "forbidden",
+      message: "Invalid admin token"
+    }
+  });
+}
+
+function shouldAttachAdminTokenToAnalyticsSink(endpoint: string | null): boolean {
+  if (!endpoint) {
+    return false;
+  }
+
+  try {
+    const url = new URL(endpoint);
+    return (
+      url.pathname === "/api/test/analytics/events" &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function buildAnalyticsSinkHeaders(endpoint: string | null): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json; charset=utf-8"
+  };
+  if (shouldAttachAdminTokenToAnalyticsSink(endpoint)) {
+    const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+    if (adminToken) {
+      headers["X-Veil-Admin-Token"] = adminToken;
+    }
+  }
+  return headers;
+}
+
+function requireAnalyticsTestAdminToken(request: IncomingMessage, response: ServerResponse): boolean {
+  const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+  if (!adminToken) {
+    sendAdminTokenNotConfigured(response);
+    return false;
+  }
+
+  if (!timingSafeCompareAdminToken(request.headers["x-veil-admin-token"], adminToken)) {
+    sendInvalidAdminToken(response);
+    return false;
+  }
+
+  return true;
 }
 
 function sendTooManyRequests(response: ServerResponse): void {
@@ -488,9 +552,7 @@ async function flushEvents(env: NodeJS.ProcessEnv = process.env): Promise<void> 
   try {
     const response = await analyticsRuntimeDependencies.fetch(config.endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8"
-      },
+      headers: buildAnalyticsSinkHeaders(config.endpoint),
       body: JSON.stringify(envelope)
     });
 
@@ -566,13 +628,19 @@ export function registerAnalyticsRoutes(
   });
 
   if (options.enableTestRoutes) {
-    app.get("/api/test/analytics/events", async (_request, response) => {
+    app.get("/api/test/analytics/events", async (request, response) => {
+      if (!requireAnalyticsTestAdminToken(request, response)) {
+        return;
+      }
       sendJson(response, 200, {
         events: getCapturedAnalyticsEventsForTest()
       });
     });
 
     app.post("/api/test/analytics/events", async (request, response) => {
+      if (!requireAnalyticsTestAdminToken(request, response)) {
+        return;
+      }
       try {
         const payload = await readJsonBody(request);
         const events = Array.isArray((payload as { events?: unknown[] } | null)?.events)

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -79,7 +79,7 @@ test("registerAnalyticsRoutes keeps test capture routes disabled by default", ()
   assert.deepEqual(postPaths, ["/api/analytics/events"]);
 });
 
-test("registerAnalyticsRoutes accepts analytics batches and logs the payload when test capture routes are enabled", async () => {
+test("registerAnalyticsRoutes accepts analytics batches and logs the payload when test capture routes are enabled", async (t) => {
   let middleware:
     | ((request: never, response: TestResponse, next: () => void) => void)
     | undefined;
@@ -93,6 +93,15 @@ test("registerAnalyticsRoutes accepts analytics batches and logs the payload whe
     | ((request: never, response: TestResponse) => void | Promise<void>)
     | undefined;
   const logs: string[] = [];
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "analytics-test-admin";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+    }
+  });
 
   configureAnalyticsRuntimeDependencies({
     log: (message) => {
@@ -158,12 +167,63 @@ test("registerAnalyticsRoutes accepts analytics batches and logs the payload whe
   assert.match(logs[0] ?? "", /^\[Analytics\] accepted 2 event\(s\) into stdout sink$/);
 
   const getResponse = createResponse();
-  await getHandler(createRequest("GET") as never, getResponse);
+  await getHandler(
+    createRequest("GET", undefined, {
+      "x-veil-admin-token": "analytics-test-admin"
+    }) as never,
+    getResponse
+  );
 
   assert.equal(getResponse.statusCode, 200);
   assert.deepEqual(JSON.parse(getResponse.body), {
     events: [{ name: "shop_open", playerId: "player-1" }, { name: "battle_start", playerId: "player-1" }]
   });
+});
+
+test("registerAnalyticsRoutes protects test analytics capture routes with the admin token", async (t) => {
+  let getHandler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+  let testCaptureHandler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "analytics-test-admin";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+    }
+  });
+
+  registerAnalyticsRoutes(
+    {
+      use() {},
+      get(_path, nextHandler) {
+        getHandler = nextHandler as never;
+      },
+      post(path, nextHandler) {
+        if (path === "/api/test/analytics/events") {
+          testCaptureHandler = nextHandler as never;
+        }
+      }
+    },
+    { enableTestRoutes: true }
+  );
+
+  assert(getHandler);
+  assert(testCaptureHandler);
+
+  const getResponse = createResponse();
+  await getHandler(createRequest("GET") as never, getResponse);
+  assert.equal(getResponse.statusCode, 403);
+  assert.equal(JSON.parse(getResponse.body).error.code, "forbidden");
+
+  const postResponse = createResponse();
+  await testCaptureHandler(createRequest("POST", JSON.stringify({ events: [] })) as never, postResponse);
+  assert.equal(postResponse.statusCode, 403);
+  assert.equal(JSON.parse(postResponse.body).error.code, "forbidden");
 });
 
 test("registerAnalyticsRoutes rejects public analytics ingest without an auth session", async () => {

--- a/apps/server/test/wechat-payment-flow.test.ts
+++ b/apps/server/test/wechat-payment-flow.test.ts
@@ -20,6 +20,8 @@ import {
 } from "@server/adapters/wechat-pay";
 import type { ShopProduct } from "@server/domain/economy/shop";
 
+const ANALYTICS_TEST_ADMIN_TOKEN = "analytics-test-admin";
+
 const TEST_PRODUCTS: Partial<ShopProduct>[] = [
   {
     productId: "gem-pack-premium",
@@ -234,7 +236,11 @@ function createSignedCallbackRequest(
 }
 
 async function fetchCapturedAnalytics(baseUrl: string): Promise<AnalyticsEvent[]> {
-  const response = await fetch(`${baseUrl}/api/test/analytics/events`);
+  const response = await fetch(`${baseUrl}/api/test/analytics/events`, {
+    headers: {
+      "x-veil-admin-token": ANALYTICS_TEST_ADMIN_TOKEN
+    }
+  });
   assert.equal(response.status, 200);
   const payload = (await response.json()) as { events?: AnalyticsEvent[] };
   return payload.events ?? [];
@@ -246,7 +252,8 @@ test("wechat payment callback settles the order, emits purchase analytics, and d
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`,
+    VEIL_ADMIN_TOKEN: ANALYTICS_TEST_ADMIN_TOKEN
   });
   const server = await startWechatPaymentServer({
     port,
@@ -337,7 +344,8 @@ test("wechat payment verify settles a created order and emits purchase analytics
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`,
+    VEIL_ADMIN_TOKEN: ANALYTICS_TEST_ADMIN_TOKEN
   });
   const server = await startWechatPaymentServer({
     port,
@@ -399,7 +407,8 @@ test("wechat payment verify returns amount mismatch without granting rewards and
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`,
+    VEIL_ADMIN_TOKEN: ANALYTICS_TEST_ADMIN_TOKEN
   });
   const server = await startWechatPaymentServer({
     port,
@@ -468,7 +477,8 @@ test("wechat payment verify emits purchase_failed when settlement cannot grant r
   const runtimeConfig = createWechatPayConfig();
   const store = await createVerifiedTestStore();
   const restoreEnv = withEnvOverrides({
-    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/test/analytics/events`,
+    VEIL_ADMIN_TOKEN: ANALYTICS_TEST_ADMIN_TOKEN
   });
   const originalCompletePaymentOrder = store.completePaymentOrder.bind(store);
   store.completePaymentOrder = async (orderId, input) => {


### PR DESCRIPTION
Closes #1684

Summary:
- Require the admin token on /api/test/analytics/events GET and POST capture routes.
- Preserve internal analytics sink forwarding by attaching the configured admin token for local test capture endpoints.
- Update analytics and WeChat payment-flow tests to use the protected capture endpoint.

Validation:
- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/analytics.test.ts apps/server/test/wechat-payment-flow.test.ts
- npm run typecheck -- server