### PR TITLE
Trim token delivery DLQ on hydration

### DIFF
--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -502,10 +502,11 @@ export async function configureAccountTokenDeliveryQueuePersistence(
   deadLetterDeliveries.clear();
 
   if (queuePersistence) {
-    const [queued, deadLetters] = await Promise.all([
+    const [queued, loadedDeadLetters] = await Promise.all([
       queuePersistence.loadQueuedDeliveries(),
       queuePersistence.loadDeadLetterDeliveries()
     ]);
+    const deadLetters = await trimHydratedDeadLetters(queuePersistence, loadedDeadLetters);
     for (const entry of queued) {
       queuedDeliveries.set(entry.key, entry);
     }
@@ -576,6 +577,24 @@ async function deleteDeadLetterDelivery(key: string): Promise<void> {
 
 async function closeRedisClient(redis: RedisClientLike | null): Promise<void> {
   await redis?.quit?.();
+}
+
+async function trimHydratedDeadLetters(
+  persistence: AccountTokenDeliveryQueuePersistence,
+  deadLetters: QueuedDeliveryEntry[]
+): Promise<QueuedDeliveryEntry[]> {
+  const maxEntries = persistence.deadLetterMaxEntries;
+  if (maxEntries == null || deadLetters.length <= maxEntries) {
+    return deadLetters;
+  }
+
+  const overflow = Math.max(0, Math.floor(deadLetters.length - maxEntries));
+  const droppedEntries = deadLetters.slice(0, overflow);
+  for (const entry of droppedEntries) {
+    await persistence.deleteDeadLetterDelivery(entry.key);
+  }
+  recordAuthTokenDeliveryDeadLetterDrop(droppedEntries.length);
+  return deadLetters.slice(overflow);
 }
 
 function applyDeadLetterDrops(droppedKeys: string[]): void {

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -563,6 +563,60 @@ test("redis token delivery persistence caps dead-letter retention", async () => 
   );
 });
 
+test("startup hydration trims preexisting dead-letter overflow and records drops", async () => {
+  resetRuntimeObservability();
+  const namespace = `account-token-delivery:hydrate-cap:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 2
+  });
+
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:oldest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:oldest", 1_800_000_000_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:middle",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:middle", 1_800_000_060_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:newest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:newest", 1_800_000_120_000))
+  );
+  await redis.rpush(
+    deadLetterListKey,
+    "password-recovery:oldest",
+    "password-recovery:middle",
+    "password-recovery:newest"
+  );
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+
+  assert.deepEqual(listAccountTokenDeliveryDeadLetters().map((entry) => entry.key), [
+    "password-recovery:newest",
+    "password-recovery:middle"
+  ]);
+  assert.deepEqual(
+    (await persistence.loadDeadLetterDeliveries()).map((entry) => entry.key),
+    ["password-recovery:middle", "password-recovery:newest"]
+  );
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_count 2$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_drops_total 1$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_capacity_used_ratio 1$/m);
+
+  resetRuntimeObservability();
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
 test("dead-letter cap evicts in-memory entries and records drops", async (t) => {
   resetRuntimeObservability();
   const redis = new MemoryRedisClient();


### PR DESCRIPTION
## Summary
- trim preexisting token-delivery dead-letter overflow during persistence hydration
- delete overflowed Redis entries before loading them into memory
- add a regression test that seeds an oversized legacy DLQ and verifies drop telemetry

## Testing
- `node --import tsx --test --test-name-pattern "(caps dead-letter retention|startup hydration trims preexisting dead-letter overflow and records drops|avoids full-list LREM scans)" apps/server/test/account-token-delivery.test.ts`
- `npm run typecheck -- server`
- `git diff --check`

Closes #1756