### PR TITLE
Fix Redis matchmaking batch writes

### DIFF
--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -579,9 +579,12 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     return requestsByPlayerId;
   }
 
-  private async createMatchResult(players: [MatchmakingRequest, MatchmakingRequest], now: Date): Promise<MatchResult> {
+  private createMatchResult(
+    players: [MatchmakingRequest, MatchmakingRequest],
+    now: Date,
+    sequence: number
+  ): MatchResult {
     const orderedPlayerIds = [players[0].playerId, players[1].playerId].sort() as [string, string];
-    const sequence = await this.redis.incr(this.sequenceKey);
 
     return {
       roomId: `pvp-match-${now.getTime()}-${sequence}`,
@@ -592,25 +595,67 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
 
   private async matchQueuedPlayers(now: Date): Promise<void> {
     const requestsByPlayerId = await this.loadQueueRequests();
+    const matchedPairs: Array<[MatchmakingRequest, MatchmakingRequest]> = [];
 
     while (requestsByPlayerId.size >= 2) {
       const queue = Array.from(requestsByPlayerId.values());
       const selection = selectBestMatchPair(queue, now);
       if (!selection) {
-        return;
+        break;
       }
 
       const [left, right] = selection.players;
       requestsByPlayerId.delete(left.playerId);
       requestsByPlayerId.delete(right.playerId);
-      await this.redis.zrem(this.queueKey, left.playerId, right.playerId);
-      await this.redis.hdel(this.requestKey, left.playerId, right.playerId);
+      matchedPairs.push([left, right]);
+    }
 
-      const result = await this.createMatchResult([left, right], now);
+    if (matchedPairs.length === 0) {
+      return;
+    }
+
+    const lastSequence = Number(
+      await this.redis.eval(
+        "return redis.call('incrby', KEYS[1], ARGV[1])",
+        1,
+        this.sequenceKey,
+        String(matchedPairs.length)
+      )
+    );
+    const firstSequence = lastSequence - matchedPairs.length + 1;
+    const batchArgs: string[] = [];
+    const notifications: Array<{ result: MatchResult; players: [MatchmakingRequest, MatchmakingRequest] }> = [];
+
+    for (const [index, players] of matchedPairs.entries()) {
+      const [left, right] = players;
+      const result = this.createMatchResult(players, now, firstSequence + index);
       const encodedResult = JSON.stringify(result);
-      await this.redis.hset(this.resultKey, left.playerId, encodedResult);
-      await this.redis.hset(this.resultKey, right.playerId, encodedResult);
-      this.onMatchCreated?.(result, [left, right]);
+      batchArgs.push(left.playerId, right.playerId, encodedResult);
+      notifications.push({ result, players });
+    }
+
+    await this.redis.eval(
+      [
+        "for index = 1, #ARGV, 3 do",
+        "  local left = ARGV[index]",
+        "  local right = ARGV[index + 1]",
+        "  local result = ARGV[index + 2]",
+        "  redis.call('zrem', KEYS[1], left, right)",
+        "  redis.call('hdel', KEYS[2], left, right)",
+        "  redis.call('hset', KEYS[3], left, result)",
+        "  redis.call('hset', KEYS[3], right, result)",
+        "end",
+        "return #ARGV / 3"
+      ].join("\n"),
+      3,
+      this.queueKey,
+      this.requestKey,
+      this.resultKey,
+      ...batchArgs
+    );
+
+    for (const { result, players } of notifications) {
+      this.onMatchCreated?.(result, players);
     }
   }
 
@@ -631,11 +676,31 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await delay(this.lockRetryDelayMs);
     }
 
+    const renewInterval = setInterval(() => {
+      void this.renewLock(token);
+    }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
+
     try {
       return await action();
     } finally {
+      clearInterval(renewInterval);
       await this.releaseLock(token);
     }
+  }
+
+  private async renewLock(token: string): Promise<void> {
+    await this.redis.eval(
+      [
+        "if redis.call('get', KEYS[1]) == ARGV[1] then",
+        "  return redis.call('pexpire', KEYS[1], ARGV[2])",
+        "end",
+        "return 0"
+      ].join("\n"),
+      1,
+      this.lockKey,
+      token,
+      String(this.lockTimeoutMs)
+    );
   }
 
   private async releaseLock(token: string): Promise<void> {

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -357,3 +357,81 @@ test("redis matchmaking batches queue request reads while draining multiple pair
   assert.equal(hmgetCalls.length, 1);
   assert.equal(hgetCalls.length, 0);
 });
+
+test("redis matchmaking drains matched pairs with bounded Redis write round trips", async (t) => {
+  const redis = new Redis();
+  const keyPrefix = "test:matchmaking:batch-write";
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix,
+    lockRetryDelayMs: 1
+  });
+  const queueKey = `${keyPrefix}:queue`;
+  const requestKey = `${keyPrefix}:requests`;
+  const resultKey = `${keyPrefix}:results`;
+  const evalCalls: unknown[][] = [];
+  const zremCalls: unknown[][] = [];
+  const hdelCalls: unknown[][] = [];
+  const hsetCalls: unknown[][] = [];
+  const incrCalls: unknown[][] = [];
+  const originalEval = redis.eval.bind(redis);
+  const originalZrem = redis.zrem.bind(redis);
+  const originalHdel = redis.hdel.bind(redis);
+  const originalHset = redis.hset.bind(redis);
+  const originalIncr = redis.incr.bind(redis);
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    evalCalls.push(args);
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  (redis as unknown as { zrem: (...args: unknown[]) => Promise<number> }).zrem = async (...args) => {
+    zremCalls.push(args);
+    return originalZrem(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hdel: (...args: unknown[]) => Promise<number> }).hdel = async (...args) => {
+    hdelCalls.push(args);
+    return originalHdel(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hset: (...args: unknown[]) => Promise<number> }).hset = async (...args) => {
+    hsetCalls.push(args);
+    return originalHset(...(args as [string, string, string]));
+  };
+  (redis as unknown as { incr: (...args: unknown[]) => Promise<number> }).incr = async (...args) => {
+    incrCalls.push(args);
+    return originalIncr(...(args as [string]));
+  };
+
+  t.after(async () => {
+    await service.close();
+  });
+
+  const requests = [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:00.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:01.000Z"),
+    createQueueRequest("player-gamma", "2026-03-28T08:00:02.000Z"),
+    createQueueRequest("player-delta", "2026-03-28T08:00:03.000Z")
+  ];
+
+  for (const [index, request] of requests.entries()) {
+    await redis.zadd(queueKey, index, request.playerId);
+    await redis.hset(requestKey, request.playerId, JSON.stringify(request));
+  }
+  hsetCalls.length = 0;
+
+  await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+    service,
+    new Date("2026-03-28T08:05:00.000Z")
+  );
+
+  assert.equal(await redis.zcard(queueKey), 0);
+  assert.equal(zremCalls.length, 0);
+  assert.equal(hdelCalls.length, 0);
+  assert.equal(hsetCalls.length, 0);
+  assert.equal(incrCalls.length, 0);
+  assert.equal(evalCalls.length, 2);
+
+  const resultAlpha = JSON.parse((await redis.hget(resultKey, "player-alpha")) ?? "{}") as { roomId?: string };
+  const resultGamma = JSON.parse((await redis.hget(resultKey, "player-gamma")) ?? "{}") as { roomId?: string };
+  assert.match(resultAlpha.roomId ?? "", /-1$/);
+  assert.match(resultGamma.roomId ?? "", /-2$/);
+});


### PR DESCRIPTION
## Summary
- batch Redis matchmaking queue removals and result writes after pair selection
- allocate continuous match sequences with a single Redis `INCRBY` eval
- renew the Redis matchmaking lock while an action is in progress

## Verification
- `NODE_PATH=/Users/grace/Documents/project/codex/ProjectVeil/node_modules node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/server/test/matchmaking-service.test.ts`
- `npm run typecheck -- server`
- `git diff --check`

Closes #1759