### PR TITLE
Read token delivery DLQ admin state from Redis

### DIFF
--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -111,6 +111,7 @@ export interface AccountTokenDeliveryQueuePersistence {
   readonly deadLetterMaxEntries?: number;
   loadQueuedDeliveries(): Promise<QueuedDeliveryEntry[]>;
   loadDeadLetterDeliveries(): Promise<QueuedDeliveryEntry[]>;
+  loadDeadLetterDelivery(key: string): Promise<QueuedDeliveryEntry | null>;
   saveQueuedDelivery(entry: QueuedDeliveryEntry): Promise<void>;
   deleteQueuedDelivery(key: string): Promise<void>;
   saveDeadLetterDelivery(entry: QueuedDeliveryEntry): Promise<string[]>;
@@ -446,6 +447,21 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     }
   };
 
+  const loadEntry = async (hashKey: string, listKey: string, key: string): Promise<QueuedDeliveryEntry | null> => {
+    const serialized = await redis.hget(hashKey, key);
+    if (!serialized) {
+      return null;
+    }
+
+    const entry = parseQueuedDeliveryEntry(serialized);
+    if (!entry) {
+      await redis.hdel(hashKey, key);
+      await redis.lrem(listKey, 1, key);
+      return null;
+    }
+    return entry;
+  };
+
   const enforceDeadLetterCap = async (): Promise<string[]> => {
     const length = await redis.llen(deadLetterListKey);
     const overflow = length - deadLetterMaxEntries;
@@ -474,6 +490,7 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     deadLetterMaxEntries,
     loadQueuedDeliveries: () => loadEntries(queuedHashKey, queuedListKey),
     loadDeadLetterDeliveries: () => loadEntries(deadLetterHashKey, deadLetterListKey),
+    loadDeadLetterDelivery: (key) => loadEntry(deadLetterHashKey, deadLetterListKey, key),
     saveQueuedDelivery: (entry) => saveEntry(queuedHashKey, queuedListKey, entry),
     deleteQueuedDelivery: (key) => deleteEntry(queuedHashKey, queuedListKey, key),
     saveDeadLetterDelivery: (entry) => saveDeadLetterEntry(entry),
@@ -1253,8 +1270,18 @@ export async function shutdownAccountTokenDeliveryQueuePersistence(): Promise<vo
   }
 }
 
-export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueueEntrySnapshot[] {
-  return Array.from(deadLetterDeliveries.values())
+export async function listAccountTokenDeliveryDeadLetters(): Promise<AccountTokenDeliveryQueueEntrySnapshot[]> {
+  let entries = Array.from(deadLetterDeliveries.values());
+  if (queuePersistence) {
+    entries = await queuePersistence.loadDeadLetterDeliveries();
+    deadLetterDeliveries.clear();
+    for (const entry of entries) {
+      deadLetterDeliveries.set(entry.key, entry);
+    }
+    syncQueueTelemetry();
+  }
+
+  return entries
     .sort((left, right) => right.nextAttemptAt - left.nextAttemptAt)
     .map(snapshotQueueEntry);
 }
@@ -1262,7 +1289,9 @@ export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueue
 export async function requeueAccountTokenDeliveryDeadLetter(
   key: string
 ): Promise<AccountTokenDeliveryQueueEntrySnapshot | null> {
-  const entry = deadLetterDeliveries.get(key);
+  const entry = queuePersistence
+    ? await queuePersistence.loadDeadLetterDelivery(key)
+    : deadLetterDeliveries.get(key);
   if (!entry) {
     return null;
   }

--- a/apps/server/src/domain/ops/admin-console.ts
+++ b/apps/server/src/domain/ops/admin-console.ts
@@ -1215,7 +1215,7 @@ export function registerAdminRoutes(
     if (!requireSupportRole(response, request, ["admin", "support-supervisor"])) return;
     sendJson(response, 200, {
       serverTime: new Date().toISOString(),
-      deadLetters: listAccountTokenDeliveryDeadLetters()
+      deadLetters: await listAccountTokenDeliveryDeadLetters()
     });
   });
 

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   listAccountTokenDeliveryDeadLetters,
   readAccountRegistrationDeliveryMode,
   readPasswordRecoveryDeliveryMode,
+  requeueAccountTokenDeliveryDeadLetter,
   resetAccountTokenDeliveryState
 } from "@server/adapters/account-token-delivery";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
@@ -563,6 +564,44 @@ test("redis token delivery persistence caps dead-letter retention", async () => 
   );
 });
 
+test("admin dead-letter list and requeue read Redis persistence instead of local process cache", async () => {
+  const namespace = `account-token-delivery:admin-cross-pod:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const queuedHashKey = `${namespace}:queued`;
+  const queuedListKey = `${namespace}:queued-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 10
+  });
+  const entry = createQueuedDeliveryEntry("password-recovery:remote-pod", 1_800_000_180_000);
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+  await redis.hset(deadLetterHashKey, entry.key, JSON.stringify(entry));
+  await redis.rpush(deadLetterListKey, entry.key);
+
+  const deadLetters = await listAccountTokenDeliveryDeadLetters();
+  assert.deepEqual(deadLetters.map((snapshot) => snapshot.key), [entry.key]);
+
+  resetAccountTokenDeliveryState();
+  const requeued = await requeueAccountTokenDeliveryDeadLetter(entry.key);
+
+  assert.equal(requeued?.key, entry.key);
+  assert.equal(await redis.hget(deadLetterHashKey, entry.key), null);
+  const persistedQueued = JSON.parse((await redis.hget(queuedHashKey, entry.key)) ?? "{}") as {
+    key?: string;
+    attemptCount?: number;
+  };
+  assert.equal(persistedQueued.key, entry.key);
+  assert.equal(persistedQueued.attemptCount, 0);
+  assert.deepEqual(await redis.lrange(deadLetterListKey, 0, -1), []);
+  assert.deepEqual(await redis.lrange(queuedListKey, 0, -1), [entry.key]);
+
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
 test("dead-letter cap evicts in-memory entries and records drops", async (t) => {
   resetRuntimeObservability();
   const redis = new MemoryRedisClient();
@@ -605,7 +644,7 @@ test("dead-letter cap evicts in-memory entries and records drops", async (t) => 
     );
   }
 
-  const deadLetterKeys = listAccountTokenDeliveryDeadLetters().map((entry) => entry.key);
+  const deadLetterKeys = (await listAccountTokenDeliveryDeadLetters()).map((entry) => entry.key);
   assert.equal(deadLetterKeys.includes("password-recovery:oldest"), false);
   assert.deepEqual(new Set(deadLetterKeys), new Set(["password-recovery:middle", "password-recovery:newest"]));
 

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -1147,6 +1147,7 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     createAccountTokenDeliveryQueuePersistence: () => ({
       loadQueuedDeliveries: async () => [],
       loadDeadLetterDeliveries: async () => [],
+      loadDeadLetterDelivery: async () => null,
       saveQueuedDelivery: async () => undefined,
       deleteQueuedDelivery: async () => undefined,
       saveDeadLetterDelivery: async () => [],


### PR DESCRIPTION
## Summary
- add a persistence read path for a single token-delivery dead-letter entry
- make admin DLQ list/requeue read from Redis-backed persistence instead of only the local process cache
- keep local fallback behavior when no persistence is configured

## Verification
- `NODE_PATH=/Users/grace/Documents/project/codex/ProjectVeil/node_modules node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test --test-name-pattern "admin dead-letter list and requeue read Redis persistence" apps/server/test/account-token-delivery.test.ts`
- `NODE_PATH=/Users/grace/Documents/project/codex/ProjectVeil/node_modules node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test --test-name-pattern "admin auth-token delivery DLQ routes" apps/server/test/admin-console.test.ts`
- `npm run typecheck -- server`
- `git diff --check`

Closes #1758