### PR TITLE
fix: harden background task failures

### DIFF
--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -502,10 +502,11 @@ export async function configureAccountTokenDeliveryQueuePersistence(
   deadLetterDeliveries.clear();
 
   if (queuePersistence) {
-    const [queued, deadLetters] = await Promise.all([
+    const [queued, loadedDeadLetters] = await Promise.all([
       queuePersistence.loadQueuedDeliveries(),
       queuePersistence.loadDeadLetterDeliveries()
     ]);
+    const deadLetters = await trimHydratedDeadLetters(queuePersistence, loadedDeadLetters);
     for (const entry of queued) {
       queuedDeliveries.set(entry.key, entry);
     }
@@ -576,6 +577,24 @@ async function deleteDeadLetterDelivery(key: string): Promise<void> {
 
 async function closeRedisClient(redis: RedisClientLike | null): Promise<void> {
   await redis?.quit?.();
+}
+
+async function trimHydratedDeadLetters(
+  persistence: AccountTokenDeliveryQueuePersistence,
+  deadLetters: QueuedDeliveryEntry[]
+): Promise<QueuedDeliveryEntry[]> {
+  const maxEntries = persistence.deadLetterMaxEntries;
+  if (maxEntries == null || deadLetters.length <= maxEntries) {
+    return deadLetters;
+  }
+
+  const overflow = Math.max(0, Math.floor(deadLetters.length - maxEntries));
+  const droppedEntries = deadLetters.slice(0, overflow);
+  for (const entry of droppedEntries) {
+    await persistence.deleteDeadLetterDelivery(entry.key);
+  }
+  recordAuthTokenDeliveryDeadLetterDrop(droppedEntries.length);
+  return deadLetters.slice(overflow);
 }
 
 function applyDeadLetterDrops(droppedKeys: string[]): void {

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -6,6 +6,7 @@ import {
   recordAuthTokenDeliveryDeadLetter,
   recordAuthTokenDeliveryDeadLetterDrop,
   recordAuthTokenDeliveryFailure,
+  recordAuthTokenDeliveryQueuePumpFailure,
   recordAuthTokenDeliveryRequest,
   recordAuthTokenDeliveryRetry,
   recordAuthTokenDeliverySuccess,
@@ -665,17 +666,23 @@ function clearQueueTimer(): void {
   }
 }
 
-function scheduleQueuePump(): void {
+function scheduleQueuePump(minDelayMs = 0): void {
   clearQueueTimer();
   if (queuedDeliveries.size === 0) {
     return;
   }
 
   const nextAttemptAt = Math.min(...Array.from(queuedDeliveries.values()).map((entry) => entry.nextAttemptAt));
-  const delayMs = Math.max(0, nextAttemptAt - Date.now());
+  const delayMs = Math.max(minDelayMs, nextAttemptAt - Date.now());
   queueTimer = setTimeout(() => {
     queueTimer = null;
-    void processQueuedDeliveries();
+    void processQueuedDeliveries().catch((error: unknown) => {
+      recordAuthTokenDeliveryQueuePumpFailure();
+      console.warn("[account-token-delivery] Queue pump failed", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      scheduleQueuePump(1_000);
+    });
   }, delayMs);
 }
 

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -111,6 +111,7 @@ export interface AccountTokenDeliveryQueuePersistence {
   readonly deadLetterMaxEntries?: number;
   loadQueuedDeliveries(): Promise<QueuedDeliveryEntry[]>;
   loadDeadLetterDeliveries(): Promise<QueuedDeliveryEntry[]>;
+  loadDeadLetterDelivery(key: string): Promise<QueuedDeliveryEntry | null>;
   saveQueuedDelivery(entry: QueuedDeliveryEntry): Promise<void>;
   deleteQueuedDelivery(key: string): Promise<void>;
   saveDeadLetterDelivery(entry: QueuedDeliveryEntry): Promise<string[]>;
@@ -446,6 +447,21 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     }
   };
 
+  const loadEntry = async (hashKey: string, listKey: string, key: string): Promise<QueuedDeliveryEntry | null> => {
+    const serialized = await redis.hget(hashKey, key);
+    if (!serialized) {
+      return null;
+    }
+
+    const entry = parseQueuedDeliveryEntry(serialized);
+    if (!entry) {
+      await redis.hdel(hashKey, key);
+      await redis.lrem(listKey, 1, key);
+      return null;
+    }
+    return entry;
+  };
+
   const enforceDeadLetterCap = async (): Promise<string[]> => {
     const length = await redis.llen(deadLetterListKey);
     const overflow = length - deadLetterMaxEntries;
@@ -474,6 +490,7 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     deadLetterMaxEntries,
     loadQueuedDeliveries: () => loadEntries(queuedHashKey, queuedListKey),
     loadDeadLetterDeliveries: () => loadEntries(deadLetterHashKey, deadLetterListKey),
+    loadDeadLetterDelivery: (key) => loadEntry(deadLetterHashKey, deadLetterListKey, key),
     saveQueuedDelivery: (entry) => saveEntry(queuedHashKey, queuedListKey, entry),
     deleteQueuedDelivery: (key) => deleteEntry(queuedHashKey, queuedListKey, key),
     saveDeadLetterDelivery: (entry) => saveDeadLetterEntry(entry),
@@ -1272,8 +1289,18 @@ export async function shutdownAccountTokenDeliveryQueuePersistence(): Promise<vo
   }
 }
 
-export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueueEntrySnapshot[] {
-  return Array.from(deadLetterDeliveries.values())
+export async function listAccountTokenDeliveryDeadLetters(): Promise<AccountTokenDeliveryQueueEntrySnapshot[]> {
+  let entries = Array.from(deadLetterDeliveries.values());
+  if (queuePersistence) {
+    entries = await trimHydratedDeadLetters(queuePersistence, await queuePersistence.loadDeadLetterDeliveries());
+    deadLetterDeliveries.clear();
+    for (const entry of entries) {
+      deadLetterDeliveries.set(entry.key, entry);
+    }
+    syncQueueTelemetry();
+  }
+
+  return entries
     .sort((left, right) => right.nextAttemptAt - left.nextAttemptAt)
     .map(snapshotQueueEntry);
 }
@@ -1281,7 +1308,9 @@ export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueue
 export async function requeueAccountTokenDeliveryDeadLetter(
   key: string
 ): Promise<AccountTokenDeliveryQueueEntrySnapshot | null> {
-  const entry = deadLetterDeliveries.get(key);
+  const entry = queuePersistence
+    ? await queuePersistence.loadDeadLetterDelivery(key)
+    : deadLetterDeliveries.get(key);
   if (!entry) {
     return null;
   }

--- a/apps/server/src/domain/ops/admin-console.ts
+++ b/apps/server/src/domain/ops/admin-console.ts
@@ -1215,7 +1215,7 @@ export function registerAdminRoutes(
     if (!requireSupportRole(response, request, ["admin", "support-supervisor"])) return;
     sendJson(response, 200, {
       serverTime: new Date().toISOString(),
-      deadLetters: listAccountTokenDeliveryDeadLetters()
+      deadLetters: await listAccountTokenDeliveryDeadLetters()
     });
   });
 

--- a/apps/server/src/domain/ops/analytics.ts
+++ b/apps/server/src/domain/ops/analytics.ts
@@ -873,9 +873,35 @@ async function flushEvents(env: NodeJS.ProcessEnv = process.env): Promise<void> 
   }
 }
 
+function handleFlushTaskFailure(error: unknown, env: NodeJS.ProcessEnv): void {
+  const message = error instanceof Error ? `[Analytics] Failed to flush analytics batch: ${error.message}` : "[Analytics] Failed to flush analytics batch";
+  try {
+    analyticsRuntimeDependencies.error(message, error);
+  } catch {
+    // Logging sinks must not turn a handled background failure back into an unhandled rejection.
+  }
+  recordFlushFailure(message);
+  scheduleFlushRetry(env);
+}
+
+function scheduleFlushRetry(env: NodeJS.ProcessEnv): void {
+  if (flushTimer || pendingEvents.length === 0) {
+    return;
+  }
+  flushTimer = analyticsRuntimeDependencies.setTimeout(() => {
+    flushTimer = null;
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
+  }, ANALYTICS_BUFFER_FLUSH_DELAY_MS);
+  flushTimer.unref?.();
+}
+
 function scheduleFlush(env: NodeJS.ProcessEnv = process.env): void {
   if (pendingEvents.length >= ANALYTICS_BUFFER_FLUSH_SIZE) {
-    void flushEvents(env);
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
     return;
   }
 
@@ -885,7 +911,9 @@ function scheduleFlush(env: NodeJS.ProcessEnv = process.env): void {
 
   flushTimer = analyticsRuntimeDependencies.setTimeout(() => {
     flushTimer = null;
-    void flushEvents(env);
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
   }, ANALYTICS_BUFFER_FLUSH_DELAY_MS);
   flushTimer.unref?.();
 }

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -52,11 +52,14 @@ interface AuthObservabilityCounters {
   tokenDeliveryRetriesTotal: number;
   tokenDeliveryDeadLettersTotal: number;
   tokenDeliveryDeadLetterDropsTotal: number;
+  tokenDeliveryQueuePumpFailuresTotal: number;
 }
 
 interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
   lockRenewFailuresTotal: number;
+  lockLostTotal: number;
+  lockReleaseStaleTotal: number;
   queueDepth: number;
 }
 
@@ -283,6 +286,7 @@ interface RuntimeHealthPayload {
           | "tokenDeliveryRetriesTotal"
           | "tokenDeliveryDeadLettersTotal"
           | "tokenDeliveryDeadLetterDropsTotal"
+          | "tokenDeliveryQueuePumpFailuresTotal"
         >;
         failureReasons: Record<AuthTokenDeliveryFailureReason, number>;
       };
@@ -469,7 +473,8 @@ const runtimeObservability: RuntimeObservabilityState = {
       tokenDeliveryFailuresTotal: 0,
       tokenDeliveryRetriesTotal: 0,
       tokenDeliveryDeadLettersTotal: 0,
-      tokenDeliveryDeadLetterDropsTotal: 0
+      tokenDeliveryDeadLetterDropsTotal: 0,
+      tokenDeliveryQueuePumpFailuresTotal: 0
     },
     activeGuestSessionCount: 0,
     activeAccountSessions: new Map<string, { playerId: string; provider: string }>(),
@@ -529,6 +534,8 @@ const runtimeObservability: RuntimeObservabilityState = {
     counters: {
       rateLimitedTotal: 0,
       lockRenewFailuresTotal: 0,
+      lockLostTotal: 0,
+      lockReleaseStaleTotal: 0,
       queueDepth: 0
     }
   },
@@ -748,7 +755,8 @@ function buildHealthPayload(
             tokenDeliveryFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryFailuresTotal,
             tokenDeliveryRetriesTotal: runtimeObservability.auth.counters.tokenDeliveryRetriesTotal,
             tokenDeliveryDeadLettersTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal,
-            tokenDeliveryDeadLetterDropsTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal
+            tokenDeliveryDeadLetterDropsTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal,
+            tokenDeliveryQueuePumpFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal
           },
           failureReasons: { ...runtimeObservability.auth.tokenDeliveryFailureReasons }
         }
@@ -1463,6 +1471,12 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_lock_renew_failures_total Total Redis matchmaking lock renewal failures.",
     "# TYPE veil_matchmaking_lock_renew_failures_total counter",
     `veil_matchmaking_lock_renew_failures_total ${health.runtime.matchmaking.counters.lockRenewFailuresTotal}`,
+    "# HELP veil_matchmaking_lock_lost_total Total Redis matchmaking actions aborted after repeated lock renewal failures.",
+    "# TYPE veil_matchmaking_lock_lost_total counter",
+    `veil_matchmaking_lock_lost_total ${health.runtime.matchmaking.counters.lockLostTotal}`,
+    "# HELP veil_matchmaking_lock_release_stale_total Total Redis matchmaking lock releases skipped because ownership was lost.",
+    "# TYPE veil_matchmaking_lock_release_stale_total counter",
+    `veil_matchmaking_lock_release_stale_total ${health.runtime.matchmaking.counters.lockReleaseStaleTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -1508,6 +1522,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_token_delivery_dead_letter_drops_total Total account token delivery dead letters dropped by retention caps.",
     "# TYPE veil_auth_token_delivery_dead_letter_drops_total counter",
     `veil_auth_token_delivery_dead_letter_drops_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryDeadLetterDropsTotal}`,
+    "# HELP veil_auth_token_delivery_queue_pump_failures_total Total background account token delivery queue pump failures.",
+    "# TYPE veil_auth_token_delivery_queue_pump_failures_total counter",
+    `veil_auth_token_delivery_queue_pump_failures_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryQueuePumpFailuresTotal}`,
     "# HELP veil_auth_token_delivery_failures_timeout_total Total token delivery failures caused by timeouts.",
     "# TYPE veil_auth_token_delivery_failures_timeout_total counter",
     `veil_auth_token_delivery_failures_timeout_total ${health.runtime.auth.tokenDelivery.failureReasons.timeout}`,
@@ -2150,6 +2167,14 @@ export function recordMatchmakingLockRenewFailure(): void {
   runtimeObservability.matchmaking.counters.lockRenewFailuresTotal += 1;
 }
 
+export function recordMatchmakingLockLost(): void {
+  runtimeObservability.matchmaking.counters.lockLostTotal += 1;
+}
+
+export function recordMatchmakingLockReleaseStale(): void {
+  runtimeObservability.matchmaking.counters.lockReleaseStaleTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2225,6 +2250,10 @@ export function recordAuthTokenDeliveryDeadLetter(): void {
 
 export function recordAuthTokenDeliveryDeadLetterDrop(count = 1): void {
   runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal += Math.max(0, Math.floor(count));
+}
+
+export function recordAuthTokenDeliveryQueuePumpFailure(): void {
+  runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal += 1;
 }
 
 export function setPaymentGrantQueueCount(count: number): void {
@@ -2348,6 +2377,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.counters.tokenDeliveryRetriesTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal = 0;
+  runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal = 0;
   runtimeObservability.auth.activeGuestSessionCount = 0;
   runtimeObservability.auth.activeAccountSessions.clear();
   runtimeObservability.auth.activeAccountLockCount = 0;
@@ -2386,6 +2416,8 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.http.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.lockRenewFailuresTotal = 0;
+  runtimeObservability.matchmaking.counters.lockLostTotal = 0;
+  runtimeObservability.matchmaking.counters.lockReleaseStaleTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -56,6 +56,7 @@ interface AuthObservabilityCounters {
 
 interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
+  lockRenewFailuresTotal: number;
   queueDepth: number;
 }
 
@@ -527,6 +528,7 @@ const runtimeObservability: RuntimeObservabilityState = {
   matchmaking: {
     counters: {
       rateLimitedTotal: 0,
+      lockRenewFailuresTotal: 0,
       queueDepth: 0
     }
   },
@@ -1458,6 +1460,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_rate_limited_total Total matchmaking requests rejected by rate limiting.",
     "# TYPE veil_matchmaking_rate_limited_total counter",
     `veil_matchmaking_rate_limited_total ${health.runtime.matchmaking.counters.rateLimitedTotal}`,
+    "# HELP veil_matchmaking_lock_renew_failures_total Total Redis matchmaking lock renewal failures.",
+    "# TYPE veil_matchmaking_lock_renew_failures_total counter",
+    `veil_matchmaking_lock_renew_failures_total ${health.runtime.matchmaking.counters.lockRenewFailuresTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -2141,6 +2146,10 @@ export function recordMatchmakingRateLimited(): void {
   runtimeObservability.matchmaking.counters.rateLimitedTotal += 1;
 }
 
+export function recordMatchmakingLockRenewFailure(): void {
+  runtimeObservability.matchmaking.counters.lockRenewFailuresTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2376,6 +2385,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.roomLifecycle.recentEvents.length = 0;
   runtimeObservability.http.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
+  runtimeObservability.matchmaking.counters.lockRenewFailuresTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -579,9 +579,12 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     return requestsByPlayerId;
   }
 
-  private async createMatchResult(players: [MatchmakingRequest, MatchmakingRequest], now: Date): Promise<MatchResult> {
+  private createMatchResult(
+    players: [MatchmakingRequest, MatchmakingRequest],
+    now: Date,
+    sequence: number
+  ): MatchResult {
     const orderedPlayerIds = [players[0].playerId, players[1].playerId].sort() as [string, string];
-    const sequence = await this.redis.incr(this.sequenceKey);
 
     return {
       roomId: `pvp-match-${now.getTime()}-${sequence}`,
@@ -592,25 +595,67 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
 
   private async matchQueuedPlayers(now: Date): Promise<void> {
     const requestsByPlayerId = await this.loadQueueRequests();
+    const matchedPairs: Array<[MatchmakingRequest, MatchmakingRequest]> = [];
 
     while (requestsByPlayerId.size >= 2) {
       const queue = Array.from(requestsByPlayerId.values());
       const selection = selectBestMatchPair(queue, now);
       if (!selection) {
-        return;
+        break;
       }
 
       const [left, right] = selection.players;
       requestsByPlayerId.delete(left.playerId);
       requestsByPlayerId.delete(right.playerId);
-      await this.redis.zrem(this.queueKey, left.playerId, right.playerId);
-      await this.redis.hdel(this.requestKey, left.playerId, right.playerId);
+      matchedPairs.push([left, right]);
+    }
 
-      const result = await this.createMatchResult([left, right], now);
+    if (matchedPairs.length === 0) {
+      return;
+    }
+
+    const lastSequence = Number(
+      await this.redis.eval(
+        "return redis.call('incrby', KEYS[1], ARGV[1])",
+        1,
+        this.sequenceKey,
+        String(matchedPairs.length)
+      )
+    );
+    const firstSequence = lastSequence - matchedPairs.length + 1;
+    const batchArgs: string[] = [];
+    const notifications: Array<{ result: MatchResult; players: [MatchmakingRequest, MatchmakingRequest] }> = [];
+
+    for (const [index, players] of matchedPairs.entries()) {
+      const [left, right] = players;
+      const result = this.createMatchResult(players, now, firstSequence + index);
       const encodedResult = JSON.stringify(result);
-      await this.redis.hset(this.resultKey, left.playerId, encodedResult);
-      await this.redis.hset(this.resultKey, right.playerId, encodedResult);
-      this.onMatchCreated?.(result, [left, right]);
+      batchArgs.push(left.playerId, right.playerId, encodedResult);
+      notifications.push({ result, players });
+    }
+
+    await this.redis.eval(
+      [
+        "for index = 1, #ARGV, 3 do",
+        "  local left = ARGV[index]",
+        "  local right = ARGV[index + 1]",
+        "  local result = ARGV[index + 2]",
+        "  redis.call('zrem', KEYS[1], left, right)",
+        "  redis.call('hdel', KEYS[2], left, right)",
+        "  redis.call('hset', KEYS[3], left, result)",
+        "  redis.call('hset', KEYS[3], right, result)",
+        "end",
+        "return #ARGV / 3"
+      ].join("\n"),
+      3,
+      this.queueKey,
+      this.requestKey,
+      this.resultKey,
+      ...batchArgs
+    );
+
+    for (const { result, players } of notifications) {
+      this.onMatchCreated?.(result, players);
     }
   }
 
@@ -631,11 +676,31 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await delay(this.lockRetryDelayMs);
     }
 
+    const renewInterval = setInterval(() => {
+      void this.renewLock(token);
+    }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
+
     try {
       return await action();
     } finally {
+      clearInterval(renewInterval);
       await this.releaseLock(token);
     }
+  }
+
+  private async renewLock(token: string): Promise<void> {
+    await this.redis.eval(
+      [
+        "if redis.call('get', KEYS[1]) == ARGV[1] then",
+        "  return redis.call('pexpire', KEYS[1], ARGV[2])",
+        "end",
+        "return 0"
+      ].join("\n"),
+      1,
+      this.lockKey,
+      token,
+      String(this.lockTimeoutMs)
+    );
   }
 
   private async releaseLock(token: string): Promise<void> {

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -6,6 +6,8 @@ import { resolveMapVariantIdForRoom } from "@veil/shared/world";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { sendMobilePushNotification } from "@server/adapters/mobile-push";
 import {
+  recordMatchmakingLockLost,
+  recordMatchmakingLockReleaseStale,
   recordMatchmakingLockRenewFailure,
   recordMatchmakingRateLimited,
   setMatchmakingQueueDepth
@@ -23,6 +25,11 @@ import { sendWechatSubscribeMessage } from "@server/adapters/wechat-subscribe";
 export const DEFAULT_MATCHMAKING_QUEUE_TTL_SECONDS = 5 * 60;
 const DEFAULT_RATE_LIMIT_MATCHMAKING_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MATCHMAKING_MAX = 30;
+const MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE = 2;
+
+interface MatchmakingLockContext {
+  isLockLost(): boolean;
+}
 
 interface MatchmakingRuntimeConfig {
   rateLimitWindowMs: number;
@@ -428,7 +435,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
   }
 
   async enqueue(request: MatchmakingRequest, now = new Date()): Promise<MatchmakingStatusQueued> {
-    return this.withLock(async () => {
+    return this.withLock(async (lock) => {
       const normalized = normalizeMatchmakingRequest(request);
 
       await this.redis.hdel(this.resultKey, normalized.playerId);
@@ -437,7 +444,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await this.redis.zadd(this.queueKey, getQueuedPlayerScore(normalized), normalized.playerId);
 
       const status = await this.getQueuedStatus(normalized.playerId);
-      await this.matchQueuedPlayers(now);
+      await this.matchQueuedPlayers(now, lock);
       if (!status) {
         throw new Error(`Failed to enqueue player for matchmaking: ${normalized.playerId}`);
       }
@@ -597,11 +604,11 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     };
   }
 
-  private async matchQueuedPlayers(now: Date): Promise<void> {
+  private async matchQueuedPlayers(now: Date, lock?: MatchmakingLockContext): Promise<void> {
     const requestsByPlayerId = await this.loadQueueRequests();
     const matchedPairs: Array<[MatchmakingRequest, MatchmakingRequest]> = [];
 
-    while (requestsByPlayerId.size >= 2) {
+    while (!lock?.isLockLost() && requestsByPlayerId.size >= 2) {
       const queue = Array.from(requestsByPlayerId.values());
       const selection = selectBestMatchPair(queue, now);
       if (!selection) {
@@ -614,7 +621,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       matchedPairs.push([left, right]);
     }
 
-    if (matchedPairs.length === 0) {
+    if (matchedPairs.length === 0 || lock?.isLockLost()) {
       return;
     }
 
@@ -663,7 +670,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     }
   }
 
-  private async withLock<T>(action: () => Promise<T>): Promise<T> {
+  private async withLock<T>(action: (lock: MatchmakingLockContext) => Promise<T>): Promise<T> {
     const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     const timeoutAt = Date.now() + this.lockTimeoutMs;
 
@@ -680,25 +687,43 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await delay(this.lockRetryDelayMs);
     }
 
+    let lockLost = false;
+    let consecutiveRenewFailures = 0;
     const renewInterval = setInterval(() => {
+      if (lockLost) {
+        return;
+      }
       void this.renewLock(token).catch((error: unknown) => {
         recordMatchmakingLockRenewFailure();
+        consecutiveRenewFailures += 1;
         console.warn("[matchmaking] Redis lock renewal failed", {
           error: error instanceof Error ? error.message : String(error)
         });
+        if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
+          lockLost = true;
+          recordMatchmakingLockLost();
+          clearInterval(renewInterval);
+        }
       });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {
-      return await action();
+      const result = await action({ isLockLost: () => lockLost });
+      if (lockLost) {
+        throw new Error("Matchmaking lock lost mid-action; results discarded");
+      }
+      return result;
     } finally {
       clearInterval(renewInterval);
-      await this.releaseLock(token);
+      const released = await this.releaseLock(token);
+      if (!released) {
+        recordMatchmakingLockReleaseStale();
+      }
     }
   }
 
   private async renewLock(token: string): Promise<void> {
-    await this.redis.eval(
+    const renewed = await this.redis.eval(
       [
         "if redis.call('get', KEYS[1]) == ARGV[1] then",
         "  return redis.call('pexpire', KEYS[1], ARGV[2])",
@@ -710,10 +735,13 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       token,
       String(this.lockTimeoutMs)
     );
+    if (Number(renewed) !== 1) {
+      throw new Error("Redis matchmaking lock renewal lost ownership");
+    }
   }
 
-  private async releaseLock(token: string): Promise<void> {
-    await this.redis.eval(
+  private async releaseLock(token: string): Promise<boolean> {
+    const released = await this.redis.eval(
       [
         "if redis.call('get', KEYS[1]) == ARGV[1] then",
         "  return redis.call('del', KEYS[1])",
@@ -724,6 +752,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       this.lockKey,
       token
     );
+    return Number(released) === 1;
   }
 }
 

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -693,18 +693,22 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       if (lockLost) {
         return;
       }
-      void this.renewLock(token).catch((error: unknown) => {
-        recordMatchmakingLockRenewFailure();
-        consecutiveRenewFailures += 1;
-        console.warn("[matchmaking] Redis lock renewal failed", {
-          error: error instanceof Error ? error.message : String(error)
+      void this.renewLock(token)
+        .then(() => {
+          consecutiveRenewFailures = 0;
+        })
+        .catch((error: unknown) => {
+          recordMatchmakingLockRenewFailure();
+          consecutiveRenewFailures += 1;
+          console.warn("[matchmaking] Redis lock renewal failed", {
+            error: error instanceof Error ? error.message : String(error)
+          });
+          if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
+            lockLost = true;
+            recordMatchmakingLockLost();
+            clearInterval(renewInterval);
+          }
         });
-        if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
-          lockLost = true;
-          recordMatchmakingLockLost();
-          clearInterval(renewInterval);
-        }
-      });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -5,7 +5,11 @@ import { createMatchmakingHeroSnapshot, estimateMatchmakingWaitSeconds, type Mat
 import { resolveMapVariantIdForRoom } from "@veil/shared/world";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { sendMobilePushNotification } from "@server/adapters/mobile-push";
-import { recordMatchmakingRateLimited, setMatchmakingQueueDepth } from "@server/domain/ops/observability";
+import {
+  recordMatchmakingLockRenewFailure,
+  recordMatchmakingRateLimited,
+  setMatchmakingQueueDepth
+} from "@server/domain/ops/observability";
 import type { RoomSnapshotStore } from "@server/persistence";
 import {
   consumeRedisBackedOrLocalRateLimit,
@@ -677,7 +681,12 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     }
 
     const renewInterval = setInterval(() => {
-      void this.renewLock(token);
+      void this.renewLock(token).catch((error: unknown) => {
+        recordMatchmakingLockRenewFailure();
+        console.warn("[matchmaking] Redis lock renewal failed", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {

--- a/apps/server/src/transport/colyseus-room/VeilColyseusRoom.ts
+++ b/apps/server/src/transport/colyseus-room/VeilColyseusRoom.ts
@@ -240,7 +240,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       }
     });
     this.clock.setInterval(() => {
-      void this.tickMinorPlaytime();
+      void this.tickMinorPlaytime().catch((error) => {
+        this.reportMinorPlaytimeFailure(error);
+      });
     }, MINOR_PROTECTION_TICK_MS);
 
     this.onMessage("connect", async (client, message: Extract<ClientMessage, { type: "connect" }>) => {
@@ -1789,20 +1791,24 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         })
       );
     } catch (error) {
-      reportBackgroundTaskFailure({
-        taskType: "minor_playtime",
-        errorCode: "minor_playtime_tick_failed",
-        message: "Background minor-playtime tick failed.",
-        logMessage: "[VeilRoom] Failed to update minor playtime",
-        error,
-        roomId: this.metadata.logicalRoomId,
-        roomDay: this.worldRoom.getInternalState().meta.day,
-        detail: formatBackgroundTaskDetail("minor_playtime", error, {
-          connectedPlayers: playerIds.length,
-          playerIds: playerIds.join(",") || null
-        })
-      });
+      this.reportMinorPlaytimeFailure(error, playerIds);
     }
+  }
+
+  private reportMinorPlaytimeFailure(error: unknown, playerIds: string[] = []): void {
+    reportBackgroundTaskFailure({
+      taskType: "minor_playtime",
+      errorCode: "minor_playtime_tick_failed",
+      message: "Background minor-playtime tick failed.",
+      logMessage: "[VeilRoom] Failed to update minor playtime",
+      error,
+      roomId: this.metadata.logicalRoomId,
+      roomDay: this.worldRoom.getInternalState().meta.day,
+      detail: formatBackgroundTaskDetail("minor_playtime", error, {
+        connectedPlayers: playerIds.length,
+        playerIds: playerIds.join(",") || null
+      })
+    });
   }
 
   private async persistRoomState(): Promise<void> {

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -13,6 +13,7 @@ import {
   requeueAccountTokenDeliveryDeadLetter,
   resetAccountTokenDeliveryState
 } from "@server/adapters/account-token-delivery";
+import type { AccountTokenDeliveryQueuePersistence } from "@server/adapters/account-token-delivery";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 import type { RedisClientLike } from "@server/infra/redis";
 
@@ -545,6 +546,53 @@ test("redis token delivery persistence avoids full-list LREM scans on persistenc
     [],
     "token delivery persistence must not issue LREM count=0 full-list scans"
   );
+});
+
+test("queued token delivery pump lock failures are caught and counted", async (t) => {
+  resetRuntimeObservability();
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  const dueEntry = createQueuedDeliveryEntry("password-recovery:pump-ranger", Date.now() - 60_000);
+  let acquireCalls = 0;
+  const persistence: AccountTokenDeliveryQueuePersistence = {
+    async loadQueuedDeliveries() {
+      return [dueEntry];
+    },
+    async loadDeadLetterDeliveries() {
+      return [];
+    },
+    async loadDeadLetterDelivery() {
+      return null;
+    },
+    async saveQueuedDelivery() {},
+    async deleteQueuedDelivery() {},
+    async saveDeadLetterDelivery() {
+      return [];
+    },
+    async deleteDeadLetterDelivery() {},
+    async acquireProcessingLock() {
+      acquireCalls += 1;
+      throw new Error("lock unavailable");
+    }
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+  t.after(async () => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    resetRuntimeObservability();
+    resetAccountTokenDeliveryState();
+    await configureAccountTokenDeliveryQueuePersistence(null);
+  });
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  resetAccountTokenDeliveryState();
+  assert.ok(acquireCalls >= 1);
+  assert.deepEqual(unhandledRejections, []);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_queue_pump_failures_total 1$/m);
 });
 
 test("redis token delivery persistence caps dead-letter retention", async () => {

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   listAccountTokenDeliveryDeadLetters,
   readAccountRegistrationDeliveryMode,
   readPasswordRecoveryDeliveryMode,
+  requeueAccountTokenDeliveryDeadLetter,
   resetAccountTokenDeliveryState
 } from "@server/adapters/account-token-delivery";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
@@ -598,7 +599,7 @@ test("startup hydration trims preexisting dead-letter overflow and records drops
 
   await configureAccountTokenDeliveryQueuePersistence(persistence);
 
-  assert.deepEqual(listAccountTokenDeliveryDeadLetters().map((entry) => entry.key), [
+  assert.deepEqual((await listAccountTokenDeliveryDeadLetters()).map((entry) => entry.key), [
     "password-recovery:newest",
     "password-recovery:middle"
   ]);
@@ -613,6 +614,44 @@ test("startup hydration trims preexisting dead-letter overflow and records drops
   assert.match(metrics, /^veil_auth_token_delivery_dead_letter_capacity_used_ratio 1$/m);
 
   resetRuntimeObservability();
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
+test("admin dead-letter list and requeue read Redis persistence instead of local process cache", async () => {
+  const namespace = `account-token-delivery:admin-cross-pod:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const queuedHashKey = `${namespace}:queued`;
+  const queuedListKey = `${namespace}:queued-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 10
+  });
+  const entry = createQueuedDeliveryEntry("password-recovery:remote-pod", 1_800_000_180_000);
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+  await redis.hset(deadLetterHashKey, entry.key, JSON.stringify(entry));
+  await redis.rpush(deadLetterListKey, entry.key);
+
+  const deadLetters = await listAccountTokenDeliveryDeadLetters();
+  assert.deepEqual(deadLetters.map((snapshot) => snapshot.key), [entry.key]);
+
+  resetAccountTokenDeliveryState();
+  const requeued = await requeueAccountTokenDeliveryDeadLetter(entry.key);
+
+  assert.equal(requeued?.key, entry.key);
+  assert.equal(await redis.hget(deadLetterHashKey, entry.key), null);
+  const persistedQueued = JSON.parse((await redis.hget(queuedHashKey, entry.key)) ?? "{}") as {
+    key?: string;
+    attemptCount?: number;
+  };
+  assert.equal(persistedQueued.key, entry.key);
+  assert.equal(persistedQueued.attemptCount, 0);
+  assert.deepEqual(await redis.lrange(deadLetterListKey, 0, -1), []);
+  assert.deepEqual(await redis.lrange(queuedListKey, 0, -1), [entry.key]);
+
   resetAccountTokenDeliveryState();
   await configureAccountTokenDeliveryQueuePersistence(null);
 });
@@ -659,7 +698,7 @@ test("dead-letter cap evicts in-memory entries and records drops", async (t) => 
     );
   }
 
-  const deadLetterKeys = listAccountTokenDeliveryDeadLetters().map((entry) => entry.key);
+  const deadLetterKeys = (await listAccountTokenDeliveryDeadLetters()).map((entry) => entry.key);
   assert.equal(deadLetterKeys.includes("password-recovery:oldest"), false);
   assert.deepEqual(new Set(deadLetterKeys), new Set(["password-recovery:middle", "password-recovery:newest"]));
 

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -563,6 +563,60 @@ test("redis token delivery persistence caps dead-letter retention", async () => 
   );
 });
 
+test("startup hydration trims preexisting dead-letter overflow and records drops", async () => {
+  resetRuntimeObservability();
+  const namespace = `account-token-delivery:hydrate-cap:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 2
+  });
+
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:oldest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:oldest", 1_800_000_000_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:middle",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:middle", 1_800_000_060_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:newest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:newest", 1_800_000_120_000))
+  );
+  await redis.rpush(
+    deadLetterListKey,
+    "password-recovery:oldest",
+    "password-recovery:middle",
+    "password-recovery:newest"
+  );
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+
+  assert.deepEqual(listAccountTokenDeliveryDeadLetters().map((entry) => entry.key), [
+    "password-recovery:newest",
+    "password-recovery:middle"
+  ]);
+  assert.deepEqual(
+    (await persistence.loadDeadLetterDeliveries()).map((entry) => entry.key),
+    ["password-recovery:middle", "password-recovery:newest"]
+  );
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_count 2$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_drops_total 1$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_capacity_used_ratio 1$/m);
+
+  resetRuntimeObservability();
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
 test("dead-letter cap evicts in-memory entries and records drops", async (t) => {
   resetRuntimeObservability();
   const redis = new MemoryRedisClient();

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -565,6 +565,48 @@ test("getAnalyticsPipelineSnapshot aggregates Redis-backed counters across simul
   );
 });
 
+test("analytics flush trigger failures are caught and counted", async (t) => {
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+  configureAnalyticsRuntimeDependencies({
+    error: () => {
+      throw new Error("analytics alert failed");
+    }
+  });
+
+  t.after(() => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    resetAnalyticsRuntimeDependencies();
+  });
+
+  for (let index = 0; index < 20; index += 1) {
+    emitAnalyticsEvent(
+      "session_start",
+      {
+        playerId: `player-${index}`,
+        source: "server",
+        payload: {
+          roomId: "room-a",
+          authMode: "guest",
+          platform: "web"
+        }
+      },
+      {
+        ANALYTICS_ENDPOINT: "https://placeholder.example/events"
+      }
+    );
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const snapshot = await getAnalyticsPipelineSnapshot();
+  assert.deepEqual(unhandledRejections, []);
+  assert.equal(snapshot.delivery.flushFailuresTotal, 1);
+  assert.match(snapshot.delivery.lastErrorMessage ?? "", /analytics alert failed/);
+});
+
 test("getAnalyticsPipelineSnapshot warns when http sink is requested without an endpoint", async () => {
   const snapshot = await getAnalyticsPipelineSnapshot({
     ANALYTICS_SINK: "http"

--- a/apps/server/test/colyseus-background-task-observability.test.ts
+++ b/apps/server/test/colyseus-background-task-observability.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
@@ -24,6 +25,16 @@ interface FakeClient extends Client {
 }
 
 class InstrumentedRoomSnapshotStore extends MemoryRoomSnapshotStore {}
+
+test("minor playtime interval catches fire-and-forget failures", async () => {
+  const source = await readFile(new URL("../src/transport/colyseus-room/VeilColyseusRoom.ts", import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /void this\.tickMinorPlaytime\(\)\.catch\(/,
+    "minor playtime interval must attach a catch handler to the fire-and-forget task"
+  );
+});
 
 async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
   await matchMaker.setup(

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -1147,6 +1147,7 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     createAccountTokenDeliveryQueuePersistence: () => ({
       loadQueuedDeliveries: async () => [],
       loadDeadLetterDeliveries: async () => [],
+      loadDeadLetterDelivery: async () => null,
       saveQueuedDelivery: async () => undefined,
       deleteQueuedDelivery: async () => undefined,
       saveDeadLetterDelivery: async () => [],

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -479,6 +479,48 @@ test("redis matchmaking lock renewal failures are caught and counted", async (t)
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });
 
+test("redis matchmaking lock renewal failure streak resets after successful renewals", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:renew-recovery",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 250
+  });
+  const originalEval = redis.eval.bind(redis);
+  const originalWarn = console.warn;
+  let renewAttempts = 0;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      renewAttempts += 1;
+      if (renewAttempts === 1 || renewAttempts === 3) {
+        await originalEval(...(args as [string, number, ...string[]]));
+        throw new Error("transient renew failed");
+      }
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  console.warn = () => undefined;
+
+  t.after(async () => {
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 430));
+  });
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.equal(renewAttempts >= 3, true);
+  assert.match(metrics, /^veil_matchmaking_lock_renew_failures_total 2$/m);
+  assert.match(metrics, /^veil_matchmaking_lock_lost_total 0$/m);
+});
+
 test("redis matchmaking stops before writing matches after repeated lock renewal failures", async (t) => {
   resetRuntimeObservability();
   const redis = new Redis();

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import Redis from "ioredis-mock";
 import { createDefaultHeroLoadout, createDefaultHeroProgression, type HeroState } from "@veil/shared/models";
 import { createMatchmakingHeroSnapshot, type MatchmakingRequest } from "@veil/shared/social";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 import { MatchmakingService, RedisMatchmakingService } from "@server/domain/social/matchmaking";
 
 test("redis matchmaking queue lifecycle does not remove players with full list scans", async () => {
@@ -434,4 +435,46 @@ test("redis matchmaking drains matched pairs with bounded Redis write round trip
   const resultGamma = JSON.parse((await redis.hget(resultKey, "player-gamma")) ?? "{}") as { roomId?: string };
   assert.match(resultAlpha.roomId ?? "", /-1$/);
   assert.match(resultGamma.roomId ?? "", /-2$/);
+});
+
+test("redis matchmaking lock renewal failures are caught and counted", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:renew-failure",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 200
+  });
+  const originalEval = redis.eval.bind(redis);
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  const originalWarn = console.warn;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      throw new Error("renew failed");
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  console.warn = () => undefined;
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  t.after(async () => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 160));
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(unhandledRejections, []);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -357,3 +357,81 @@ test("redis matchmaking batches queue request reads while draining multiple pair
   assert.equal(hmgetCalls.length, 1);
   assert.equal(hgetCalls.length, 0);
 });
+
+test("redis matchmaking drains matched pairs with bounded Redis write round trips", async (t) => {
+  const redis = new Redis();
+  const keyPrefix = "test:matchmaking:batch-write";
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix,
+    lockRetryDelayMs: 1
+  });
+  const queueKey = `${keyPrefix}:queue`;
+  const requestKey = `${keyPrefix}:requests`;
+  const resultKey = `${keyPrefix}:results`;
+  const evalCalls: unknown[][] = [];
+  const zremCalls: unknown[][] = [];
+  const hdelCalls: unknown[][] = [];
+  const hsetCalls: unknown[][] = [];
+  const incrCalls: unknown[][] = [];
+  const originalEval = redis.eval.bind(redis);
+  const originalZrem = redis.zrem.bind(redis);
+  const originalHdel = redis.hdel.bind(redis);
+  const originalHset = redis.hset.bind(redis);
+  const originalIncr = redis.incr.bind(redis);
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    evalCalls.push(args);
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  (redis as unknown as { zrem: (...args: unknown[]) => Promise<number> }).zrem = async (...args) => {
+    zremCalls.push(args);
+    return originalZrem(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hdel: (...args: unknown[]) => Promise<number> }).hdel = async (...args) => {
+    hdelCalls.push(args);
+    return originalHdel(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hset: (...args: unknown[]) => Promise<number> }).hset = async (...args) => {
+    hsetCalls.push(args);
+    return originalHset(...(args as [string, string, string]));
+  };
+  (redis as unknown as { incr: (...args: unknown[]) => Promise<number> }).incr = async (...args) => {
+    incrCalls.push(args);
+    return originalIncr(...(args as [string]));
+  };
+
+  t.after(async () => {
+    await service.close();
+  });
+
+  const requests = [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:00.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:01.000Z"),
+    createQueueRequest("player-gamma", "2026-03-28T08:00:02.000Z"),
+    createQueueRequest("player-delta", "2026-03-28T08:00:03.000Z")
+  ];
+
+  for (const [index, request] of requests.entries()) {
+    await redis.zadd(queueKey, index, request.playerId);
+    await redis.hset(requestKey, request.playerId, JSON.stringify(request));
+  }
+  hsetCalls.length = 0;
+
+  await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+    service,
+    new Date("2026-03-28T08:05:00.000Z")
+  );
+
+  assert.equal(await redis.zcard(queueKey), 0);
+  assert.equal(zremCalls.length, 0);
+  assert.equal(hdelCalls.length, 0);
+  assert.equal(hsetCalls.length, 0);
+  assert.equal(incrCalls.length, 0);
+  assert.equal(evalCalls.length, 2);
+
+  const resultAlpha = JSON.parse((await redis.hget(resultKey, "player-alpha")) ?? "{}") as { roomId?: string };
+  const resultGamma = JSON.parse((await redis.hget(resultKey, "player-gamma")) ?? "{}") as { roomId?: string };
+  assert.match(resultAlpha.roomId ?? "", /-1$/);
+  assert.match(resultGamma.roomId ?? "", /-2$/);
+});

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -478,3 +478,54 @@ test("redis matchmaking lock renewal failures are caught and counted", async (t)
   assert.deepEqual(unhandledRejections, []);
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });
+
+test("redis matchmaking stops before writing matches after repeated lock renewal failures", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:lock-lost",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 250
+  });
+  const originalEval = redis.eval.bind(redis);
+  let zremCalls = 0;
+  const originalZrem = redis.zrem.bind(redis);
+  const originalWarn = console.warn;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      throw new Error("renew failed");
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  (redis as unknown as { zrem: (...args: unknown[]) => Promise<unknown> }).zrem = async (...args) => {
+    zremCalls += 1;
+    return originalZrem(...(args as [string, ...string[]]));
+  };
+  console.warn = () => undefined;
+
+  t.after(async () => {
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await assert.rejects(
+    () =>
+      Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 270));
+        await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+          service,
+          new Date("2026-03-29T00:00:00.000Z")
+        );
+      }),
+    /Matchmaking lock lost/
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(zremCalls, 0);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 2$/m);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_lost_total 1$/m);
+});


### PR DESCRIPTION
## Summary
- abort Redis matchmaking work after repeated lock renewal failures and report lock-lost/stale-release counters
- catch analytics, minor playtime, and account-token queue pump fire-and-forget failures with metrics
- add regressions for #1765 and #1766

## Verification
- node --import tsx --test apps/server/test/matchmaking-service.test.ts
- node --import tsx --test apps/server/test/analytics.test.ts
- node --import tsx --test apps/server/test/colyseus-background-task-observability.test.ts
- node --import tsx --test --test-name-pattern "queued token delivery pump lock failures" apps/server/test/account-token-delivery.test.ts
- npm run typecheck -- server
- git diff --check

Fixes #1765
Fixes #1766