### PR TITLE
Fix H5 session metadata escaping

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -4933,7 +4933,7 @@ function render(): void {
         <h1>H5 调试壳</h1>
         <p class="lead">这里保留给浏览器调试、配置联调和回归验证使用；主客户端运行时已切到 Cocos Creator。</p>
         <div class="session-meta-row">
-          <p class="muted" data-testid="session-meta">Room: ${roomId} · Player: ${playerId}</p>
+          <p class="muted" data-testid="session-meta">Room: ${escapeHtml(roomId)} · Player: ${escapeHtml(playerId)}</p>
           <button class="session-link" data-toggle-achievements="true">${state.achievementPanel.open ? "收起成就" : "成就面板"}</button>
           <button class="session-link" data-return-lobby="true">返回大厅</button>
           <button class="session-link" data-logout-guest="true">切换游客账号</button>

--- a/apps/client/test/main-session-meta.test.ts
+++ b/apps/client/test/main-session-meta.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+function installFakeBrowser(search: string): { app: { innerHTML: string } } {
+  const storage = {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined
+  };
+  const app = {
+    innerHTML: "",
+    querySelectorAll: () => [],
+    querySelector: () => null
+  };
+  const fakeElement = () => ({
+    style: {},
+    append: () => undefined,
+    click: () => undefined,
+    remove: () => undefined,
+    setAttribute: () => undefined,
+    addEventListener: () => undefined,
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    innerHTML: "",
+    textContent: "",
+    id: ""
+  });
+
+  Object.assign(globalThis, {
+    window: {
+      location: {
+        search,
+        protocol: "http:",
+        hostname: "127.0.0.1",
+        href: `http://127.0.0.1:4173/${search}`
+      },
+      localStorage: storage,
+      setTimeout,
+      clearTimeout
+    },
+    document: {
+      createElement: fakeElement,
+      body: {
+        appendChild: () => undefined
+      },
+      querySelector: (selector: string) => (selector === "#app" ? app : null),
+      addEventListener: () => undefined
+    }
+  });
+
+  return { app };
+}
+
+test("H5 session metadata escapes query-derived room and player identifiers", async () => {
+  globalThis.__PROJECT_VEIL_MAIN_SKIP_AUTO_BOOT__ = true;
+  const { app } = installFakeBrowser(
+    "?roomId=%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E&playerId=%3Csvg%20onload%3Dalert(2)%3E"
+  );
+  const { startMainH5Boot } = await import("../src/main");
+
+  startMainH5Boot({
+    launchMainH5AppImpl: (({ render }) => {
+      render();
+    }) as never
+  });
+
+  assert.match(
+    app.innerHTML,
+    /Room: &lt;img src=x onerror=alert\(1\)&gt; · Player: &lt;svg onload=alert\(2\)&gt;/
+  );
+  assert.doesNotMatch(app.innerHTML, /<img src=x onerror=alert\(1\)>/);
+  assert.doesNotMatch(app.innerHTML, /<svg onload=alert\(2\)>/);
+});

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -502,10 +502,11 @@ export async function configureAccountTokenDeliveryQueuePersistence(
   deadLetterDeliveries.clear();
 
   if (queuePersistence) {
-    const [queued, deadLetters] = await Promise.all([
+    const [queued, loadedDeadLetters] = await Promise.all([
       queuePersistence.loadQueuedDeliveries(),
       queuePersistence.loadDeadLetterDeliveries()
     ]);
+    const deadLetters = await trimHydratedDeadLetters(queuePersistence, loadedDeadLetters);
     for (const entry of queued) {
       queuedDeliveries.set(entry.key, entry);
     }
@@ -576,6 +577,24 @@ async function deleteDeadLetterDelivery(key: string): Promise<void> {
 
 async function closeRedisClient(redis: RedisClientLike | null): Promise<void> {
   await redis?.quit?.();
+}
+
+async function trimHydratedDeadLetters(
+  persistence: AccountTokenDeliveryQueuePersistence,
+  deadLetters: QueuedDeliveryEntry[]
+): Promise<QueuedDeliveryEntry[]> {
+  const maxEntries = persistence.deadLetterMaxEntries;
+  if (maxEntries == null || deadLetters.length <= maxEntries) {
+    return deadLetters;
+  }
+
+  const overflow = Math.max(0, Math.floor(deadLetters.length - maxEntries));
+  const droppedEntries = deadLetters.slice(0, overflow);
+  for (const entry of droppedEntries) {
+    await persistence.deleteDeadLetterDelivery(entry.key);
+  }
+  recordAuthTokenDeliveryDeadLetterDrop(droppedEntries.length);
+  return deadLetters.slice(overflow);
 }
 
 function applyDeadLetterDrops(droppedKeys: string[]): void {

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -6,6 +6,9 @@ import {
   recordAuthTokenDeliveryDeadLetter,
   recordAuthTokenDeliveryDeadLetterDrop,
   recordAuthTokenDeliveryFailure,
+  recordAuthTokenDeliveryProcessingLockLost,
+  recordAuthTokenDeliveryProcessingLockReleaseStale,
+  recordAuthTokenDeliveryProcessingLockRenewFailure,
   recordAuthTokenDeliveryQueuePumpFailure,
   recordAuthTokenDeliveryRequest,
   recordAuthTokenDeliveryRetry,
@@ -119,7 +122,8 @@ export interface AccountTokenDeliveryQueuePersistence {
   deleteDeadLetterDelivery(key: string): Promise<void>;
   clear?(): Promise<void>;
   acquireProcessingLock?(ttlMs: number): Promise<boolean>;
-  releaseProcessingLock?(): Promise<void>;
+  renewProcessingLock?(ttlMs: number): Promise<void>;
+  releaseProcessingLock?(): Promise<boolean | void>;
 }
 
 export interface AccountTokenDeliveryResult {
@@ -170,6 +174,11 @@ const DEFAULT_SMTPS_PORT = 465;
 const DEFAULT_QUEUE_PERSISTENCE_NAMESPACE = "veil:account-token-delivery";
 const DEFAULT_DEAD_LETTER_MAX_ENTRIES = 1_000;
 const QUEUE_PROCESSING_LOCK_TTL_MS = 30_000;
+const QUEUE_PROCESSING_LOCK_RENEW_FAILURE_TOLERANCE = 2;
+
+interface QueueProcessingLockContext {
+  isLockLost(): boolean;
+}
 
 const queuedDeliveries = new Map<string, QueuedDeliveryEntry>();
 const deadLetterDeliveries = new Map<string, QueuedDeliveryEntry>();
@@ -499,13 +508,26 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     clear: () => redis.del(queuedHashKey, queuedListKey, deadLetterHashKey, deadLetterListKey, processingLockKey).then(() => undefined),
     acquireProcessingLock: async (ttlMs) =>
       (await redis.set(processingLockKey, lockOwner, "PX", ttlMs, "NX")) === "OK",
+    renewProcessingLock: async (ttlMs) => {
+      const renewed = await redis.eval(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+        1,
+        processingLockKey,
+        lockOwner,
+        String(ttlMs)
+      );
+      if (Number(renewed) !== 1) {
+        throw new Error("Account token delivery processing lock renewal lost ownership");
+      }
+    },
     releaseProcessingLock: async () => {
-      await redis.eval(
+      const released = await redis.eval(
         "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
         1,
         processingLockKey,
         lockOwner
       );
+      return Number(released) === 1;
     }
   };
 }
@@ -1155,24 +1177,68 @@ async function processQueuedDelivery(entry: QueuedDeliveryEntry): Promise<void> 
   }
 }
 
+async function withQueueProcessingLock(action: (lock: QueueProcessingLockContext) => Promise<void>): Promise<void> {
+  if (!queuePersistence?.acquireProcessingLock) {
+    await action({ isLockLost: () => false });
+    return;
+  }
+
+  const lockAcquired = await queuePersistence.acquireProcessingLock(QUEUE_PROCESSING_LOCK_TTL_MS);
+  if (!lockAcquired) {
+    scheduleQueuePump();
+    return;
+  }
+
+  let lockLost = false;
+  let consecutiveRenewFailures = 0;
+  const renewInterval =
+    queuePersistence.renewProcessingLock &&
+    setInterval(() => {
+      if (lockLost) {
+        return;
+      }
+      void queuePersistence?.renewProcessingLock?.(QUEUE_PROCESSING_LOCK_TTL_MS).catch((error: unknown) => {
+        recordAuthTokenDeliveryProcessingLockRenewFailure();
+        consecutiveRenewFailures += 1;
+        console.warn("[account-token-delivery] Processing lock renewal failed", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+        if (consecutiveRenewFailures >= QUEUE_PROCESSING_LOCK_RENEW_FAILURE_TOLERANCE) {
+          lockLost = true;
+          recordAuthTokenDeliveryProcessingLockLost();
+          if (renewInterval) {
+            clearInterval(renewInterval);
+          }
+        }
+      });
+    }, Math.max(100, Math.floor(QUEUE_PROCESSING_LOCK_TTL_MS / 2)));
+
+  try {
+    await action({ isLockLost: () => lockLost });
+    if (lockLost) {
+      throw new Error("Account token delivery processing lock lost mid-action; remaining entries deferred");
+    }
+  } finally {
+    if (renewInterval) {
+      clearInterval(renewInterval);
+    }
+    const released = await queuePersistence.releaseProcessingLock?.();
+    if (released === false) {
+      recordAuthTokenDeliveryProcessingLockReleaseStale();
+    }
+  }
+}
+
 async function processQueuedDeliveries(): Promise<void> {
   if (queueProcessing) {
     scheduleQueuePump();
     return;
   }
 
-  let lockAcquired = false;
-  if (queuePersistence?.acquireProcessingLock) {
-    lockAcquired = await queuePersistence.acquireProcessingLock(QUEUE_PROCESSING_LOCK_TTL_MS);
-    if (!lockAcquired) {
-      scheduleQueuePump();
-      return;
-    }
-  }
-
   queueProcessing = true;
   try {
-    while (true) {
+    await withQueueProcessingLock(async (lock) => {
+      while (!lock.isLockLost()) {
       const dueEntry = Array.from(queuedDeliveries.values())
         .sort((left, right) => left.nextAttemptAt - right.nextAttemptAt)[0];
       if (!dueEntry || dueEntry.nextAttemptAt > Date.now()) {
@@ -1181,15 +1247,10 @@ async function processQueuedDeliveries(): Promise<void> {
 
       await processQueuedDelivery(dueEntry);
     }
+    });
   } finally {
     queueProcessing = false;
-    try {
-      if (lockAcquired) {
-        await queuePersistence?.releaseProcessingLock?.();
-      }
-    } finally {
-      scheduleQueuePump();
-    }
+    scheduleQueuePump();
   }
 }
 

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -6,6 +6,7 @@ import {
   recordAuthTokenDeliveryDeadLetter,
   recordAuthTokenDeliveryDeadLetterDrop,
   recordAuthTokenDeliveryFailure,
+  recordAuthTokenDeliveryQueuePumpFailure,
   recordAuthTokenDeliveryRequest,
   recordAuthTokenDeliveryRetry,
   recordAuthTokenDeliverySuccess,
@@ -665,17 +666,23 @@ function clearQueueTimer(): void {
   }
 }
 
-function scheduleQueuePump(): void {
+function scheduleQueuePump(minDelayMs = 0): void {
   clearQueueTimer();
   if (queuedDeliveries.size === 0) {
     return;
   }
 
   const nextAttemptAt = Math.min(...Array.from(queuedDeliveries.values()).map((entry) => entry.nextAttemptAt));
-  const delayMs = Math.max(0, nextAttemptAt - Date.now());
+  const delayMs = Math.max(minDelayMs, nextAttemptAt - Date.now());
   queueTimer = setTimeout(() => {
     queueTimer = null;
-    void processQueuedDeliveries();
+    void processQueuedDeliveries().catch((error: unknown) => {
+      recordAuthTokenDeliveryQueuePumpFailure();
+      console.warn("[account-token-delivery] Queue pump failed", {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      scheduleQueuePump(1_000);
+    });
   }, delayMs);
 }
 

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -111,6 +111,7 @@ export interface AccountTokenDeliveryQueuePersistence {
   readonly deadLetterMaxEntries?: number;
   loadQueuedDeliveries(): Promise<QueuedDeliveryEntry[]>;
   loadDeadLetterDeliveries(): Promise<QueuedDeliveryEntry[]>;
+  loadDeadLetterDelivery(key: string): Promise<QueuedDeliveryEntry | null>;
   saveQueuedDelivery(entry: QueuedDeliveryEntry): Promise<void>;
   deleteQueuedDelivery(key: string): Promise<void>;
   saveDeadLetterDelivery(entry: QueuedDeliveryEntry): Promise<string[]>;
@@ -446,6 +447,21 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     }
   };
 
+  const loadEntry = async (hashKey: string, listKey: string, key: string): Promise<QueuedDeliveryEntry | null> => {
+    const serialized = await redis.hget(hashKey, key);
+    if (!serialized) {
+      return null;
+    }
+
+    const entry = parseQueuedDeliveryEntry(serialized);
+    if (!entry) {
+      await redis.hdel(hashKey, key);
+      await redis.lrem(listKey, 1, key);
+      return null;
+    }
+    return entry;
+  };
+
   const enforceDeadLetterCap = async (): Promise<string[]> => {
     const length = await redis.llen(deadLetterListKey);
     const overflow = length - deadLetterMaxEntries;
@@ -474,6 +490,7 @@ export function createRedisAccountTokenDeliveryQueuePersistence(
     deadLetterMaxEntries,
     loadQueuedDeliveries: () => loadEntries(queuedHashKey, queuedListKey),
     loadDeadLetterDeliveries: () => loadEntries(deadLetterHashKey, deadLetterListKey),
+    loadDeadLetterDelivery: (key) => loadEntry(deadLetterHashKey, deadLetterListKey, key),
     saveQueuedDelivery: (entry) => saveEntry(queuedHashKey, queuedListKey, entry),
     deleteQueuedDelivery: (key) => deleteEntry(queuedHashKey, queuedListKey, key),
     saveDeadLetterDelivery: (entry) => saveDeadLetterEntry(entry),
@@ -1272,8 +1289,18 @@ export async function shutdownAccountTokenDeliveryQueuePersistence(): Promise<vo
   }
 }
 
-export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueueEntrySnapshot[] {
-  return Array.from(deadLetterDeliveries.values())
+export async function listAccountTokenDeliveryDeadLetters(): Promise<AccountTokenDeliveryQueueEntrySnapshot[]> {
+  let entries = Array.from(deadLetterDeliveries.values());
+  if (queuePersistence) {
+    entries = await trimHydratedDeadLetters(queuePersistence, await queuePersistence.loadDeadLetterDeliveries());
+    deadLetterDeliveries.clear();
+    for (const entry of entries) {
+      deadLetterDeliveries.set(entry.key, entry);
+    }
+    syncQueueTelemetry();
+  }
+
+  return entries
     .sort((left, right) => right.nextAttemptAt - left.nextAttemptAt)
     .map(snapshotQueueEntry);
 }
@@ -1281,7 +1308,9 @@ export function listAccountTokenDeliveryDeadLetters(): AccountTokenDeliveryQueue
 export async function requeueAccountTokenDeliveryDeadLetter(
   key: string
 ): Promise<AccountTokenDeliveryQueueEntrySnapshot | null> {
-  const entry = deadLetterDeliveries.get(key);
+  const entry = queuePersistence
+    ? await queuePersistence.loadDeadLetterDelivery(key)
+    : deadLetterDeliveries.get(key);
   if (!entry) {
     return null;
   }

--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -1197,20 +1197,25 @@ async function withQueueProcessingLock(action: (lock: QueueProcessingLockContext
       if (lockLost) {
         return;
       }
-      void queuePersistence?.renewProcessingLock?.(QUEUE_PROCESSING_LOCK_TTL_MS).catch((error: unknown) => {
-        recordAuthTokenDeliveryProcessingLockRenewFailure();
-        consecutiveRenewFailures += 1;
-        console.warn("[account-token-delivery] Processing lock renewal failed", {
-          error: error instanceof Error ? error.message : String(error)
-        });
-        if (consecutiveRenewFailures >= QUEUE_PROCESSING_LOCK_RENEW_FAILURE_TOLERANCE) {
-          lockLost = true;
-          recordAuthTokenDeliveryProcessingLockLost();
-          if (renewInterval) {
-            clearInterval(renewInterval);
+      void queuePersistence
+        ?.renewProcessingLock?.(QUEUE_PROCESSING_LOCK_TTL_MS)
+        .then(() => {
+          consecutiveRenewFailures = 0;
+        })
+        .catch((error: unknown) => {
+          recordAuthTokenDeliveryProcessingLockRenewFailure();
+          consecutiveRenewFailures += 1;
+          console.warn("[account-token-delivery] Processing lock renewal failed", {
+            error: error instanceof Error ? error.message : String(error)
+          });
+          if (consecutiveRenewFailures >= QUEUE_PROCESSING_LOCK_RENEW_FAILURE_TOLERANCE) {
+            lockLost = true;
+            recordAuthTokenDeliveryProcessingLockLost();
+            if (renewInterval) {
+              clearInterval(renewInterval);
+            }
           }
-        }
-      });
+        });
     }, Math.max(100, Math.floor(QUEUE_PROCESSING_LOCK_TTL_MS / 2)));
 
   try {
@@ -1239,14 +1244,15 @@ async function processQueuedDeliveries(): Promise<void> {
   try {
     await withQueueProcessingLock(async (lock) => {
       while (!lock.isLockLost()) {
-      const dueEntry = Array.from(queuedDeliveries.values())
-        .sort((left, right) => left.nextAttemptAt - right.nextAttemptAt)[0];
-      if (!dueEntry || dueEntry.nextAttemptAt > Date.now()) {
-        break;
-      }
+        const dueEntry = Array.from(queuedDeliveries.values()).sort(
+          (left, right) => left.nextAttemptAt - right.nextAttemptAt
+        )[0];
+        if (!dueEntry || dueEntry.nextAttemptAt > Date.now()) {
+          break;
+        }
 
-      await processQueuedDelivery(dueEntry);
-    }
+        await processQueuedDelivery(dueEntry);
+      }
     });
   } finally {
     queueProcessing = false;

--- a/apps/server/src/domain/battle/event-engine.ts
+++ b/apps/server/src/domain/battle/event-engine.ts
@@ -10,6 +10,12 @@ import { normalizePlayerMailboxMessage } from "@server/domain/account/player-mai
 import { timingSafeCompareAdminToken } from "@server/infra/admin-token";
 import { readRuntimeSecret } from "@server/domain/ops/runtime-secrets";
 import {
+  recordSeasonalEventOpsAuditLocalFallbackWrite,
+  recordSeasonalEventOpsAuditPersistFailure,
+  recordSeasonalEventOpsAuditPersistSuccess,
+  recordSeasonalEventOpsAuditReadFailure
+} from "@server/domain/ops/observability";
+import {
   consumeRedisBackedOrLocalRateLimit,
   createLocalRateLimitState,
   type RateLimitResult
@@ -80,6 +86,7 @@ export interface SeasonalEventOpsAuditRedisClient {
   lpush(key: string, ...values: string[]): Promise<number>;
   ltrim(key: string, start: number, stop: number): Promise<unknown>;
   lrange(key: string, start: number, stop: number): Promise<string[]>;
+  del?(key: string): Promise<unknown>;
   expire?(key: string, seconds: number): Promise<unknown>;
 }
 
@@ -137,6 +144,16 @@ const seasonalEventRuntimeOverrides = new Map<string, SeasonalEventRuntimeOverri
 const seasonalEventOpsAuditTrail: SeasonalEventOpsAuditEntry[] = [];
 const actionSubmissionRateLimitState = createLocalRateLimitState();
 let defaultActionSubmissionRateLimitRedisClient: RedisClientLike | null | undefined;
+
+interface SeasonalEventOpsAuditAppendResult {
+  entry: SeasonalEventOpsAuditEntry;
+  degraded: boolean;
+}
+
+interface SeasonalEventOpsAuditListResult {
+  entries: SeasonalEventOpsAuditEntry[];
+  degraded: boolean;
+}
 
 export interface ActionSubmissionRateLimitOptions {
   redisClient?: RedisClientLike | null;
@@ -356,45 +373,57 @@ function parseSeasonalEventOpsAuditEntry(value: string): SeasonalEventOpsAuditEn
 async function appendSeasonalEventOpsAuditEntryWithSharedStore(
   entry: Omit<SeasonalEventOpsAuditEntry, "id">,
   redisClient: SeasonalEventOpsAuditRedisClient | null
-): Promise<SeasonalEventOpsAuditEntry> {
+): Promise<SeasonalEventOpsAuditAppendResult> {
   const auditEntry = createSeasonalEventOpsAuditEntry(entry);
   if (!redisClient) {
     rememberLocalSeasonalEventOpsAuditEntry(auditEntry);
-    return auditEntry;
+    return { entry: auditEntry, degraded: false };
   }
 
   try {
     await redisClient.lpush(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY, JSON.stringify(auditEntry));
     await redisClient.ltrim(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY, 0, SEASONAL_EVENT_OPS_AUDIT_MAX_ENTRIES - 1);
     await redisClient.expire?.(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY, SEASONAL_EVENT_OPS_AUDIT_TTL_SECONDS);
+    recordSeasonalEventOpsAuditPersistSuccess();
     rememberLocalSeasonalEventOpsAuditEntry(auditEntry);
-    return auditEntry;
-  } catch {
+    return { entry: auditEntry, degraded: false };
+  } catch (error) {
+    recordSeasonalEventOpsAuditPersistFailure();
+    recordSeasonalEventOpsAuditLocalFallbackWrite();
+    console.error("Seasonal event ops audit persistence failed; using local fallback", error);
     rememberLocalSeasonalEventOpsAuditEntry(auditEntry);
-    return auditEntry;
+    return { entry: auditEntry, degraded: true };
   }
 }
 
 async function listSeasonalEventOpsAuditTrailWithSharedStore(
   redisClient: SeasonalEventOpsAuditRedisClient | null
-): Promise<SeasonalEventOpsAuditEntry[]> {
+): Promise<SeasonalEventOpsAuditListResult> {
   if (!redisClient) {
-    return listSeasonalEventOpsAuditTrail();
+    return { entries: listSeasonalEventOpsAuditTrail(), degraded: false };
   }
 
   try {
-    return (await redisClient.lrange(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY, 0, SEASONAL_EVENT_OPS_AUDIT_MAX_ENTRIES - 1))
-      .map(parseSeasonalEventOpsAuditEntry)
-      .filter((entry): entry is SeasonalEventOpsAuditEntry => Boolean(entry))
-      .map(cloneSeasonalEventOpsAuditEntry);
-  } catch {
-    return listSeasonalEventOpsAuditTrail();
+    return {
+      entries: (await redisClient.lrange(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY, 0, SEASONAL_EVENT_OPS_AUDIT_MAX_ENTRIES - 1))
+        .map(parseSeasonalEventOpsAuditEntry)
+        .filter((entry): entry is SeasonalEventOpsAuditEntry => Boolean(entry))
+        .map(cloneSeasonalEventOpsAuditEntry),
+      degraded: false
+    };
+  } catch (error) {
+    recordSeasonalEventOpsAuditReadFailure();
+    console.error("Seasonal event ops audit read failed; using local fallback", error);
+    return { entries: listSeasonalEventOpsAuditTrail(), degraded: true };
   }
 }
 
-export function resetSeasonalEventRuntimeState(): void {
+export async function resetSeasonalEventRuntimeState(redisClient?: SeasonalEventOpsAuditRedisClient | null): Promise<void> {
   seasonalEventRuntimeOverrides.clear();
   seasonalEventOpsAuditTrail.length = 0;
+  if (redisClient?.del) {
+    await redisClient.del(SEASONAL_EVENT_OPS_AUDIT_REDIS_LIST_KEY);
+  }
 }
 
 function cloneSeasonalEventRuntimeOverride(override: SeasonalEventRuntimeOverride): SeasonalEventRuntimeOverride {
@@ -1677,6 +1706,7 @@ export function registerEventRoutes(
         options.eventDocuments
       );
       const accounts = store?.listPlayerAccounts ? await store.listPlayerAccounts({ limit: 10_000, offset: 0 }) : [];
+      const audit = await listSeasonalEventOpsAuditTrailWithSharedStore(seasonalEventOpsAuditRedisClient);
       sendJson(response, 200, {
         checkedAt: now.toISOString(),
         events: events.map((event) => ({
@@ -1690,7 +1720,8 @@ export function registerEventRoutes(
             : {},
           participation: buildSeasonalEventParticipationStats(event, accounts)
         })),
-        audit: await listSeasonalEventOpsAuditTrailWithSharedStore(seasonalEventOpsAuditRedisClient)
+        audit: audit.entries,
+        auditDegraded: audit.degraded
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -1750,7 +1781,7 @@ export function registerEventRoutes(
         },
         seasonalEventOpsAuditRedisClient
       );
-      sendJson(response, 200, { event: nextEvent, audit });
+      sendJson(response, 200, { event: nextEvent, audit: audit.entry, auditDegraded: audit.degraded });
     } catch (error) {
       if (error instanceof SyntaxError) {
         sendJson(response, 400, { error: { code: "invalid_json", message: "Request body must be valid JSON" } });
@@ -1842,7 +1873,8 @@ export function registerEventRoutes(
       sendJson(response, 200, {
         event: endedEvent,
         distribution,
-        audit
+        audit: audit.entry,
+        auditDegraded: audit.degraded
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -1917,7 +1949,8 @@ export function registerEventRoutes(
         playerId,
         eventId,
         account: nextAccount,
-        audit
+        audit: audit.entry,
+        auditDegraded: audit.degraded
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/src/domain/ops/admin-console.ts
+++ b/apps/server/src/domain/ops/admin-console.ts
@@ -1215,7 +1215,7 @@ export function registerAdminRoutes(
     if (!requireSupportRole(response, request, ["admin", "support-supervisor"])) return;
     sendJson(response, 200, {
       serverTime: new Date().toISOString(),
-      deadLetters: listAccountTokenDeliveryDeadLetters()
+      deadLetters: await listAccountTokenDeliveryDeadLetters()
     });
   });
 

--- a/apps/server/src/domain/ops/analytics.ts
+++ b/apps/server/src/domain/ops/analytics.ts
@@ -873,9 +873,35 @@ async function flushEvents(env: NodeJS.ProcessEnv = process.env): Promise<void> 
   }
 }
 
+function handleFlushTaskFailure(error: unknown, env: NodeJS.ProcessEnv): void {
+  const message = error instanceof Error ? `[Analytics] Failed to flush analytics batch: ${error.message}` : "[Analytics] Failed to flush analytics batch";
+  try {
+    analyticsRuntimeDependencies.error(message, error);
+  } catch {
+    // Logging sinks must not turn a handled background failure back into an unhandled rejection.
+  }
+  recordFlushFailure(message);
+  scheduleFlushRetry(env);
+}
+
+function scheduleFlushRetry(env: NodeJS.ProcessEnv): void {
+  if (flushTimer || pendingEvents.length === 0) {
+    return;
+  }
+  flushTimer = analyticsRuntimeDependencies.setTimeout(() => {
+    flushTimer = null;
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
+  }, ANALYTICS_BUFFER_FLUSH_DELAY_MS);
+  flushTimer.unref?.();
+}
+
 function scheduleFlush(env: NodeJS.ProcessEnv = process.env): void {
   if (pendingEvents.length >= ANALYTICS_BUFFER_FLUSH_SIZE) {
-    void flushEvents(env);
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
     return;
   }
 
@@ -885,7 +911,9 @@ function scheduleFlush(env: NodeJS.ProcessEnv = process.env): void {
 
   flushTimer = analyticsRuntimeDependencies.setTimeout(() => {
     flushTimer = null;
-    void flushEvents(env);
+    void flushEvents(env).catch((error: unknown) => {
+      handleFlushTaskFailure(error, env);
+    });
   }, ANALYTICS_BUFFER_FLUSH_DELAY_MS);
   flushTimer.unref?.();
 }

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -52,11 +52,14 @@ interface AuthObservabilityCounters {
   tokenDeliveryRetriesTotal: number;
   tokenDeliveryDeadLettersTotal: number;
   tokenDeliveryDeadLetterDropsTotal: number;
+  tokenDeliveryQueuePumpFailuresTotal: number;
 }
 
 interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
   lockRenewFailuresTotal: number;
+  lockLostTotal: number;
+  lockReleaseStaleTotal: number;
   queueDepth: number;
 }
 
@@ -283,6 +286,7 @@ interface RuntimeHealthPayload {
           | "tokenDeliveryRetriesTotal"
           | "tokenDeliveryDeadLettersTotal"
           | "tokenDeliveryDeadLetterDropsTotal"
+          | "tokenDeliveryQueuePumpFailuresTotal"
         >;
         failureReasons: Record<AuthTokenDeliveryFailureReason, number>;
       };
@@ -469,7 +473,8 @@ const runtimeObservability: RuntimeObservabilityState = {
       tokenDeliveryFailuresTotal: 0,
       tokenDeliveryRetriesTotal: 0,
       tokenDeliveryDeadLettersTotal: 0,
-      tokenDeliveryDeadLetterDropsTotal: 0
+      tokenDeliveryDeadLetterDropsTotal: 0,
+      tokenDeliveryQueuePumpFailuresTotal: 0
     },
     activeGuestSessionCount: 0,
     activeAccountSessions: new Map<string, { playerId: string; provider: string }>(),
@@ -529,6 +534,8 @@ const runtimeObservability: RuntimeObservabilityState = {
     counters: {
       rateLimitedTotal: 0,
       lockRenewFailuresTotal: 0,
+      lockLostTotal: 0,
+      lockReleaseStaleTotal: 0,
       queueDepth: 0
     }
   },
@@ -748,7 +755,8 @@ function buildHealthPayload(
             tokenDeliveryFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryFailuresTotal,
             tokenDeliveryRetriesTotal: runtimeObservability.auth.counters.tokenDeliveryRetriesTotal,
             tokenDeliveryDeadLettersTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal,
-            tokenDeliveryDeadLetterDropsTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal
+            tokenDeliveryDeadLetterDropsTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal,
+            tokenDeliveryQueuePumpFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal
           },
           failureReasons: { ...runtimeObservability.auth.tokenDeliveryFailureReasons }
         }
@@ -1463,6 +1471,12 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_lock_renew_failures_total Total Redis matchmaking lock renewal failures.",
     "# TYPE veil_matchmaking_lock_renew_failures_total counter",
     `veil_matchmaking_lock_renew_failures_total ${health.runtime.matchmaking.counters.lockRenewFailuresTotal}`,
+    "# HELP veil_matchmaking_lock_lost_total Total Redis matchmaking actions aborted after repeated lock renewal failures.",
+    "# TYPE veil_matchmaking_lock_lost_total counter",
+    `veil_matchmaking_lock_lost_total ${health.runtime.matchmaking.counters.lockLostTotal}`,
+    "# HELP veil_matchmaking_lock_release_stale_total Total Redis matchmaking lock releases skipped because ownership was lost.",
+    "# TYPE veil_matchmaking_lock_release_stale_total counter",
+    `veil_matchmaking_lock_release_stale_total ${health.runtime.matchmaking.counters.lockReleaseStaleTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -1508,6 +1522,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_token_delivery_dead_letter_drops_total Total account token delivery dead letters dropped by retention caps.",
     "# TYPE veil_auth_token_delivery_dead_letter_drops_total counter",
     `veil_auth_token_delivery_dead_letter_drops_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryDeadLetterDropsTotal}`,
+    "# HELP veil_auth_token_delivery_queue_pump_failures_total Total background account token delivery queue pump failures.",
+    "# TYPE veil_auth_token_delivery_queue_pump_failures_total counter",
+    `veil_auth_token_delivery_queue_pump_failures_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryQueuePumpFailuresTotal}`,
     "# HELP veil_auth_token_delivery_failures_timeout_total Total token delivery failures caused by timeouts.",
     "# TYPE veil_auth_token_delivery_failures_timeout_total counter",
     `veil_auth_token_delivery_failures_timeout_total ${health.runtime.auth.tokenDelivery.failureReasons.timeout}`,
@@ -2150,6 +2167,14 @@ export function recordMatchmakingLockRenewFailure(): void {
   runtimeObservability.matchmaking.counters.lockRenewFailuresTotal += 1;
 }
 
+export function recordMatchmakingLockLost(): void {
+  runtimeObservability.matchmaking.counters.lockLostTotal += 1;
+}
+
+export function recordMatchmakingLockReleaseStale(): void {
+  runtimeObservability.matchmaking.counters.lockReleaseStaleTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2225,6 +2250,10 @@ export function recordAuthTokenDeliveryDeadLetter(): void {
 
 export function recordAuthTokenDeliveryDeadLetterDrop(count = 1): void {
   runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal += Math.max(0, Math.floor(count));
+}
+
+export function recordAuthTokenDeliveryQueuePumpFailure(): void {
+  runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal += 1;
 }
 
 export function setPaymentGrantQueueCount(count: number): void {
@@ -2348,6 +2377,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.counters.tokenDeliveryRetriesTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal = 0;
+  runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal = 0;
   runtimeObservability.auth.activeGuestSessionCount = 0;
   runtimeObservability.auth.activeAccountSessions.clear();
   runtimeObservability.auth.activeAccountLockCount = 0;
@@ -2386,6 +2416,8 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.http.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.lockRenewFailuresTotal = 0;
+  runtimeObservability.matchmaking.counters.lockLostTotal = 0;
+  runtimeObservability.matchmaking.counters.lockReleaseStaleTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -56,6 +56,7 @@ interface AuthObservabilityCounters {
 
 interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
+  lockRenewFailuresTotal: number;
   queueDepth: number;
 }
 
@@ -527,6 +528,7 @@ const runtimeObservability: RuntimeObservabilityState = {
   matchmaking: {
     counters: {
       rateLimitedTotal: 0,
+      lockRenewFailuresTotal: 0,
       queueDepth: 0
     }
   },
@@ -1458,6 +1460,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_rate_limited_total Total matchmaking requests rejected by rate limiting.",
     "# TYPE veil_matchmaking_rate_limited_total counter",
     `veil_matchmaking_rate_limited_total ${health.runtime.matchmaking.counters.rateLimitedTotal}`,
+    "# HELP veil_matchmaking_lock_renew_failures_total Total Redis matchmaking lock renewal failures.",
+    "# TYPE veil_matchmaking_lock_renew_failures_total counter",
+    `veil_matchmaking_lock_renew_failures_total ${health.runtime.matchmaking.counters.lockRenewFailuresTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -2141,6 +2146,10 @@ export function recordMatchmakingRateLimited(): void {
   runtimeObservability.matchmaking.counters.rateLimitedTotal += 1;
 }
 
+export function recordMatchmakingLockRenewFailure(): void {
+  runtimeObservability.matchmaking.counters.lockRenewFailuresTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2376,6 +2385,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.roomLifecycle.recentEvents.length = 0;
   runtimeObservability.http.counters.rateLimitedTotal = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
+  runtimeObservability.matchmaking.counters.lockRenewFailuresTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -67,6 +67,13 @@ interface MatchmakingObservabilityCounters {
   queueDepth: number;
 }
 
+interface SeasonalEventOpsAuditObservabilityCounters {
+  persistSuccessTotal: number;
+  persistFailuresTotal: number;
+  readFailuresTotal: number;
+  localFallbackWritesTotal: number;
+}
+
 interface LeaderboardAbuseObservabilityCounters {
   alertsTotal: number;
 }
@@ -216,6 +223,9 @@ interface RuntimeObservabilityState {
   matchmaking: {
     counters: MatchmakingObservabilityCounters;
   };
+  seasonalEventOpsAudit: {
+    counters: SeasonalEventOpsAuditObservabilityCounters;
+  };
   leaderboardAbuse: {
     counters: LeaderboardAbuseObservabilityCounters;
     recentAlerts: LeaderboardAlertEvent[];
@@ -307,6 +317,9 @@ interface RuntimeHealthPayload {
     };
     matchmaking: {
       counters: MatchmakingObservabilityCounters;
+    };
+    seasonalEventOpsAudit: {
+      counters: SeasonalEventOpsAuditObservabilityCounters;
     };
     leaderboardAbuse: {
       counters: LeaderboardAbuseObservabilityCounters;
@@ -550,6 +563,14 @@ const runtimeObservability: RuntimeObservabilityState = {
       queueDepth: 0
     }
   },
+  seasonalEventOpsAudit: {
+    counters: {
+      persistSuccessTotal: 0,
+      persistFailuresTotal: 0,
+      readFailuresTotal: 0,
+      localFallbackWritesTotal: 0
+    }
+  },
   leaderboardAbuse: {
     counters: {
       alertsTotal: 0
@@ -784,6 +805,9 @@ function buildHealthPayload(
       },
       matchmaking: {
         counters: { ...runtimeObservability.matchmaking.counters }
+      },
+      seasonalEventOpsAudit: {
+        counters: { ...runtimeObservability.seasonalEventOpsAudit.counters }
       },
       leaderboardAbuse: {
         counters: { ...runtimeObservability.leaderboardAbuse.counters },
@@ -1494,6 +1518,18 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_fenced_write_rejected_total Total Redis matchmaking writes rejected by lock-token fencing.",
     "# TYPE veil_matchmaking_fenced_write_rejected_total counter",
     `veil_matchmaking_fenced_write_rejected_total ${health.runtime.matchmaking.counters.fencedWriteRejectedTotal}`,
+    "# HELP veil_seasonal_event_ops_audit_persist_success_total Total seasonal-event ops audit entries persisted to shared storage.",
+    "# TYPE veil_seasonal_event_ops_audit_persist_success_total counter",
+    `veil_seasonal_event_ops_audit_persist_success_total ${health.runtime.seasonalEventOpsAudit.counters.persistSuccessTotal}`,
+    "# HELP veil_seasonal_event_ops_audit_persist_failures_total Total seasonal-event ops audit shared-storage write failures.",
+    "# TYPE veil_seasonal_event_ops_audit_persist_failures_total counter",
+    `veil_seasonal_event_ops_audit_persist_failures_total ${health.runtime.seasonalEventOpsAudit.counters.persistFailuresTotal}`,
+    "# HELP veil_seasonal_event_ops_audit_read_failures_total Total seasonal-event ops audit shared-storage read failures.",
+    "# TYPE veil_seasonal_event_ops_audit_read_failures_total counter",
+    `veil_seasonal_event_ops_audit_read_failures_total ${health.runtime.seasonalEventOpsAudit.counters.readFailuresTotal}`,
+    "# HELP veil_seasonal_event_ops_audit_local_fallback_writes_total Total seasonal-event ops audit entries written only to local fallback after shared-storage failure.",
+    "# TYPE veil_seasonal_event_ops_audit_local_fallback_writes_total counter",
+    `veil_seasonal_event_ops_audit_local_fallback_writes_total ${health.runtime.seasonalEventOpsAudit.counters.localFallbackWritesTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -2205,6 +2241,22 @@ export function recordMatchmakingFencedWriteRejected(): void {
   runtimeObservability.matchmaking.counters.fencedWriteRejectedTotal += 1;
 }
 
+export function recordSeasonalEventOpsAuditPersistSuccess(): void {
+  runtimeObservability.seasonalEventOpsAudit.counters.persistSuccessTotal += 1;
+}
+
+export function recordSeasonalEventOpsAuditPersistFailure(): void {
+  runtimeObservability.seasonalEventOpsAudit.counters.persistFailuresTotal += 1;
+}
+
+export function recordSeasonalEventOpsAuditReadFailure(): void {
+  runtimeObservability.seasonalEventOpsAudit.counters.readFailuresTotal += 1;
+}
+
+export function recordSeasonalEventOpsAuditLocalFallbackWrite(): void {
+  runtimeObservability.seasonalEventOpsAudit.counters.localFallbackWritesTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2465,6 +2517,10 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.matchmaking.counters.lockReleaseStaleTotal = 0;
   runtimeObservability.matchmaking.counters.fencedWriteRejectedTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
+  runtimeObservability.seasonalEventOpsAudit.counters.persistSuccessTotal = 0;
+  runtimeObservability.seasonalEventOpsAudit.counters.persistFailuresTotal = 0;
+  runtimeObservability.seasonalEventOpsAudit.counters.readFailuresTotal = 0;
+  runtimeObservability.seasonalEventOpsAudit.counters.localFallbackWritesTotal = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;
   runtimeObservability.antiCheat.counters.alertsTotal = 0;

--- a/apps/server/src/domain/ops/observability.ts
+++ b/apps/server/src/domain/ops/observability.ts
@@ -53,6 +53,9 @@ interface AuthObservabilityCounters {
   tokenDeliveryDeadLettersTotal: number;
   tokenDeliveryDeadLetterDropsTotal: number;
   tokenDeliveryQueuePumpFailuresTotal: number;
+  tokenDeliveryProcessingLockRenewFailuresTotal: number;
+  tokenDeliveryProcessingLockLostTotal: number;
+  tokenDeliveryProcessingLockReleaseStaleTotal: number;
 }
 
 interface MatchmakingObservabilityCounters {
@@ -60,6 +63,7 @@ interface MatchmakingObservabilityCounters {
   lockRenewFailuresTotal: number;
   lockLostTotal: number;
   lockReleaseStaleTotal: number;
+  fencedWriteRejectedTotal: number;
   queueDepth: number;
 }
 
@@ -287,6 +291,9 @@ interface RuntimeHealthPayload {
           | "tokenDeliveryDeadLettersTotal"
           | "tokenDeliveryDeadLetterDropsTotal"
           | "tokenDeliveryQueuePumpFailuresTotal"
+          | "tokenDeliveryProcessingLockRenewFailuresTotal"
+          | "tokenDeliveryProcessingLockLostTotal"
+          | "tokenDeliveryProcessingLockReleaseStaleTotal"
         >;
         failureReasons: Record<AuthTokenDeliveryFailureReason, number>;
       };
@@ -474,7 +481,10 @@ const runtimeObservability: RuntimeObservabilityState = {
       tokenDeliveryRetriesTotal: 0,
       tokenDeliveryDeadLettersTotal: 0,
       tokenDeliveryDeadLetterDropsTotal: 0,
-      tokenDeliveryQueuePumpFailuresTotal: 0
+      tokenDeliveryQueuePumpFailuresTotal: 0,
+      tokenDeliveryProcessingLockRenewFailuresTotal: 0,
+      tokenDeliveryProcessingLockLostTotal: 0,
+      tokenDeliveryProcessingLockReleaseStaleTotal: 0
     },
     activeGuestSessionCount: 0,
     activeAccountSessions: new Map<string, { playerId: string; provider: string }>(),
@@ -536,6 +546,7 @@ const runtimeObservability: RuntimeObservabilityState = {
       lockRenewFailuresTotal: 0,
       lockLostTotal: 0,
       lockReleaseStaleTotal: 0,
+      fencedWriteRejectedTotal: 0,
       queueDepth: 0
     }
   },
@@ -756,7 +767,10 @@ function buildHealthPayload(
             tokenDeliveryRetriesTotal: runtimeObservability.auth.counters.tokenDeliveryRetriesTotal,
             tokenDeliveryDeadLettersTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal,
             tokenDeliveryDeadLetterDropsTotal: runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal,
-            tokenDeliveryQueuePumpFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal
+            tokenDeliveryQueuePumpFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal,
+            tokenDeliveryProcessingLockRenewFailuresTotal: runtimeObservability.auth.counters.tokenDeliveryProcessingLockRenewFailuresTotal,
+            tokenDeliveryProcessingLockLostTotal: runtimeObservability.auth.counters.tokenDeliveryProcessingLockLostTotal,
+            tokenDeliveryProcessingLockReleaseStaleTotal: runtimeObservability.auth.counters.tokenDeliveryProcessingLockReleaseStaleTotal
           },
           failureReasons: { ...runtimeObservability.auth.tokenDeliveryFailureReasons }
         }
@@ -1477,6 +1491,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_lock_release_stale_total Total Redis matchmaking lock releases skipped because ownership was lost.",
     "# TYPE veil_matchmaking_lock_release_stale_total counter",
     `veil_matchmaking_lock_release_stale_total ${health.runtime.matchmaking.counters.lockReleaseStaleTotal}`,
+    "# HELP veil_matchmaking_fenced_write_rejected_total Total Redis matchmaking writes rejected by lock-token fencing.",
+    "# TYPE veil_matchmaking_fenced_write_rejected_total counter",
+    `veil_matchmaking_fenced_write_rejected_total ${health.runtime.matchmaking.counters.fencedWriteRejectedTotal}`,
     "# HELP veil_matchmaking_queue_depth Current matchmaking queue depth across the active backing store.",
     "# TYPE veil_matchmaking_queue_depth gauge",
     `veil_matchmaking_queue_depth ${health.runtime.matchmaking.counters.queueDepth}`,
@@ -1525,6 +1542,15 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_token_delivery_queue_pump_failures_total Total background account token delivery queue pump failures.",
     "# TYPE veil_auth_token_delivery_queue_pump_failures_total counter",
     `veil_auth_token_delivery_queue_pump_failures_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryQueuePumpFailuresTotal}`,
+    "# HELP veil_auth_token_delivery_processing_lock_renew_failures_total Total account token delivery processing lock renewal failures.",
+    "# TYPE veil_auth_token_delivery_processing_lock_renew_failures_total counter",
+    `veil_auth_token_delivery_processing_lock_renew_failures_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryProcessingLockRenewFailuresTotal}`,
+    "# HELP veil_auth_token_delivery_processing_lock_lost_total Total account token delivery processing runs aborted after repeated lock renewal failures.",
+    "# TYPE veil_auth_token_delivery_processing_lock_lost_total counter",
+    `veil_auth_token_delivery_processing_lock_lost_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryProcessingLockLostTotal}`,
+    "# HELP veil_auth_token_delivery_processing_lock_release_stale_total Total account token delivery processing lock releases skipped because ownership was lost.",
+    "# TYPE veil_auth_token_delivery_processing_lock_release_stale_total counter",
+    `veil_auth_token_delivery_processing_lock_release_stale_total ${health.runtime.auth.tokenDelivery.counters.tokenDeliveryProcessingLockReleaseStaleTotal}`,
     "# HELP veil_auth_token_delivery_failures_timeout_total Total token delivery failures caused by timeouts.",
     "# TYPE veil_auth_token_delivery_failures_timeout_total counter",
     `veil_auth_token_delivery_failures_timeout_total ${health.runtime.auth.tokenDelivery.failureReasons.timeout}`,
@@ -2175,6 +2201,10 @@ export function recordMatchmakingLockReleaseStale(): void {
   runtimeObservability.matchmaking.counters.lockReleaseStaleTotal += 1;
 }
 
+export function recordMatchmakingFencedWriteRejected(): void {
+  runtimeObservability.matchmaking.counters.fencedWriteRejectedTotal += 1;
+}
+
 export function setMatchmakingQueueDepth(count: number): void {
   runtimeObservability.matchmaking.counters.queueDepth = Math.max(0, Math.floor(count));
 }
@@ -2254,6 +2284,18 @@ export function recordAuthTokenDeliveryDeadLetterDrop(count = 1): void {
 
 export function recordAuthTokenDeliveryQueuePumpFailure(): void {
   runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal += 1;
+}
+
+export function recordAuthTokenDeliveryProcessingLockRenewFailure(): void {
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockRenewFailuresTotal += 1;
+}
+
+export function recordAuthTokenDeliveryProcessingLockLost(): void {
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockLostTotal += 1;
+}
+
+export function recordAuthTokenDeliveryProcessingLockReleaseStale(): void {
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockReleaseStaleTotal += 1;
 }
 
 export function setPaymentGrantQueueCount(count: number): void {
@@ -2378,6 +2420,9 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryDeadLetterDropsTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryQueuePumpFailuresTotal = 0;
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockRenewFailuresTotal = 0;
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockLostTotal = 0;
+  runtimeObservability.auth.counters.tokenDeliveryProcessingLockReleaseStaleTotal = 0;
   runtimeObservability.auth.activeGuestSessionCount = 0;
   runtimeObservability.auth.activeAccountSessions.clear();
   runtimeObservability.auth.activeAccountLockCount = 0;
@@ -2418,6 +2463,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.matchmaking.counters.lockRenewFailuresTotal = 0;
   runtimeObservability.matchmaking.counters.lockLostTotal = 0;
   runtimeObservability.matchmaking.counters.lockReleaseStaleTotal = 0;
+  runtimeObservability.matchmaking.counters.fencedWriteRejectedTotal = 0;
   runtimeObservability.matchmaking.counters.queueDepth = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -9,6 +9,7 @@ import {
   recordMatchmakingLockLost,
   recordMatchmakingLockReleaseStale,
   recordMatchmakingLockRenewFailure,
+  recordMatchmakingFencedWriteRejected,
   recordMatchmakingRateLimited,
   setMatchmakingQueueDepth
 } from "@server/domain/ops/observability";
@@ -29,6 +30,7 @@ const MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE = 2;
 
 interface MatchmakingLockContext {
   isLockLost(): boolean;
+  token?: string;
 }
 
 interface MatchmakingRuntimeConfig {
@@ -627,12 +629,23 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
 
     const lastSequence = Number(
       await this.redis.eval(
-        "return redis.call('incrby', KEYS[1], ARGV[1])",
-        1,
+        [
+          "if ARGV[1] ~= '' and redis.call('get', KEYS[2]) ~= ARGV[1] then",
+          "  return -1",
+          "end",
+          "return redis.call('incrby', KEYS[1], ARGV[2])"
+        ].join("\n"),
+        2,
         this.sequenceKey,
+        this.lockKey,
+        lock?.token ?? "",
         String(matchedPairs.length)
       )
     );
+    if (lastSequence < 0 || lock?.isLockLost()) {
+      recordMatchmakingFencedWriteRejected();
+      return;
+    }
     const firstSequence = lastSequence - matchedPairs.length + 1;
     const batchArgs: string[] = [];
     const notifications: Array<{ result: MatchResult; players: [MatchmakingRequest, MatchmakingRequest] }> = [];
@@ -645,25 +658,36 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       notifications.push({ result, players });
     }
 
-    await this.redis.eval(
-      [
-        "for index = 1, #ARGV, 3 do",
-        "  local left = ARGV[index]",
-        "  local right = ARGV[index + 1]",
-        "  local result = ARGV[index + 2]",
-        "  redis.call('zrem', KEYS[1], left, right)",
-        "  redis.call('hdel', KEYS[2], left, right)",
-        "  redis.call('hset', KEYS[3], left, result)",
-        "  redis.call('hset', KEYS[3], right, result)",
-        "end",
-        "return #ARGV / 3"
-      ].join("\n"),
-      3,
-      this.queueKey,
-      this.requestKey,
-      this.resultKey,
-      ...batchArgs
+    const writtenCount = Number(
+      await this.redis.eval(
+        [
+          "if ARGV[1] ~= '' and redis.call('get', KEYS[4]) ~= ARGV[1] then",
+          "  return -1",
+          "end",
+          "for index = 2, #ARGV, 3 do",
+          "  local left = ARGV[index]",
+          "  local right = ARGV[index + 1]",
+          "  local result = ARGV[index + 2]",
+          "  redis.call('zrem', KEYS[1], left, right)",
+          "  redis.call('hdel', KEYS[2], left, right)",
+          "  redis.call('hset', KEYS[3], left, result)",
+          "  redis.call('hset', KEYS[3], right, result)",
+          "end",
+          "return (#ARGV - 1) / 3"
+        ].join("\n"),
+        4,
+        this.queueKey,
+        this.requestKey,
+        this.resultKey,
+        this.lockKey,
+        lock?.token ?? "",
+        ...batchArgs
+      )
     );
+    if (writtenCount < 0 || lock?.isLockLost()) {
+      recordMatchmakingFencedWriteRejected();
+      return;
+    }
 
     for (const { result, players } of notifications) {
       this.onMatchCreated?.(result, players);
@@ -712,7 +736,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {
-      const result = await action({ isLockLost: () => lockLost });
+      const result = await action({ isLockLost: () => lockLost, token });
       if (lockLost) {
         throw new Error("Matchmaking lock lost mid-action; results discarded");
       }

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -579,9 +579,12 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     return requestsByPlayerId;
   }
 
-  private async createMatchResult(players: [MatchmakingRequest, MatchmakingRequest], now: Date): Promise<MatchResult> {
+  private createMatchResult(
+    players: [MatchmakingRequest, MatchmakingRequest],
+    now: Date,
+    sequence: number
+  ): MatchResult {
     const orderedPlayerIds = [players[0].playerId, players[1].playerId].sort() as [string, string];
-    const sequence = await this.redis.incr(this.sequenceKey);
 
     return {
       roomId: `pvp-match-${now.getTime()}-${sequence}`,
@@ -592,25 +595,67 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
 
   private async matchQueuedPlayers(now: Date): Promise<void> {
     const requestsByPlayerId = await this.loadQueueRequests();
+    const matchedPairs: Array<[MatchmakingRequest, MatchmakingRequest]> = [];
 
     while (requestsByPlayerId.size >= 2) {
       const queue = Array.from(requestsByPlayerId.values());
       const selection = selectBestMatchPair(queue, now);
       if (!selection) {
-        return;
+        break;
       }
 
       const [left, right] = selection.players;
       requestsByPlayerId.delete(left.playerId);
       requestsByPlayerId.delete(right.playerId);
-      await this.redis.zrem(this.queueKey, left.playerId, right.playerId);
-      await this.redis.hdel(this.requestKey, left.playerId, right.playerId);
+      matchedPairs.push([left, right]);
+    }
 
-      const result = await this.createMatchResult([left, right], now);
+    if (matchedPairs.length === 0) {
+      return;
+    }
+
+    const lastSequence = Number(
+      await this.redis.eval(
+        "return redis.call('incrby', KEYS[1], ARGV[1])",
+        1,
+        this.sequenceKey,
+        String(matchedPairs.length)
+      )
+    );
+    const firstSequence = lastSequence - matchedPairs.length + 1;
+    const batchArgs: string[] = [];
+    const notifications: Array<{ result: MatchResult; players: [MatchmakingRequest, MatchmakingRequest] }> = [];
+
+    for (const [index, players] of matchedPairs.entries()) {
+      const [left, right] = players;
+      const result = this.createMatchResult(players, now, firstSequence + index);
       const encodedResult = JSON.stringify(result);
-      await this.redis.hset(this.resultKey, left.playerId, encodedResult);
-      await this.redis.hset(this.resultKey, right.playerId, encodedResult);
-      this.onMatchCreated?.(result, [left, right]);
+      batchArgs.push(left.playerId, right.playerId, encodedResult);
+      notifications.push({ result, players });
+    }
+
+    await this.redis.eval(
+      [
+        "for index = 1, #ARGV, 3 do",
+        "  local left = ARGV[index]",
+        "  local right = ARGV[index + 1]",
+        "  local result = ARGV[index + 2]",
+        "  redis.call('zrem', KEYS[1], left, right)",
+        "  redis.call('hdel', KEYS[2], left, right)",
+        "  redis.call('hset', KEYS[3], left, result)",
+        "  redis.call('hset', KEYS[3], right, result)",
+        "end",
+        "return #ARGV / 3"
+      ].join("\n"),
+      3,
+      this.queueKey,
+      this.requestKey,
+      this.resultKey,
+      ...batchArgs
+    );
+
+    for (const { result, players } of notifications) {
+      this.onMatchCreated?.(result, players);
     }
   }
 
@@ -631,11 +676,31 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await delay(this.lockRetryDelayMs);
     }
 
+    const renewInterval = setInterval(() => {
+      void this.renewLock(token);
+    }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
+
     try {
       return await action();
     } finally {
+      clearInterval(renewInterval);
       await this.releaseLock(token);
     }
+  }
+
+  private async renewLock(token: string): Promise<void> {
+    await this.redis.eval(
+      [
+        "if redis.call('get', KEYS[1]) == ARGV[1] then",
+        "  return redis.call('pexpire', KEYS[1], ARGV[2])",
+        "end",
+        "return 0"
+      ].join("\n"),
+      1,
+      this.lockKey,
+      token,
+      String(this.lockTimeoutMs)
+    );
   }
 
   private async releaseLock(token: string): Promise<void> {

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -6,6 +6,8 @@ import { resolveMapVariantIdForRoom } from "@veil/shared/world";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { sendMobilePushNotification } from "@server/adapters/mobile-push";
 import {
+  recordMatchmakingLockLost,
+  recordMatchmakingLockReleaseStale,
   recordMatchmakingLockRenewFailure,
   recordMatchmakingRateLimited,
   setMatchmakingQueueDepth
@@ -23,6 +25,11 @@ import { sendWechatSubscribeMessage } from "@server/adapters/wechat-subscribe";
 export const DEFAULT_MATCHMAKING_QUEUE_TTL_SECONDS = 5 * 60;
 const DEFAULT_RATE_LIMIT_MATCHMAKING_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MATCHMAKING_MAX = 30;
+const MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE = 2;
+
+interface MatchmakingLockContext {
+  isLockLost(): boolean;
+}
 
 interface MatchmakingRuntimeConfig {
   rateLimitWindowMs: number;
@@ -428,7 +435,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
   }
 
   async enqueue(request: MatchmakingRequest, now = new Date()): Promise<MatchmakingStatusQueued> {
-    return this.withLock(async () => {
+    return this.withLock(async (lock) => {
       const normalized = normalizeMatchmakingRequest(request);
 
       await this.redis.hdel(this.resultKey, normalized.playerId);
@@ -437,7 +444,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await this.redis.zadd(this.queueKey, getQueuedPlayerScore(normalized), normalized.playerId);
 
       const status = await this.getQueuedStatus(normalized.playerId);
-      await this.matchQueuedPlayers(now);
+      await this.matchQueuedPlayers(now, lock);
       if (!status) {
         throw new Error(`Failed to enqueue player for matchmaking: ${normalized.playerId}`);
       }
@@ -597,11 +604,11 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     };
   }
 
-  private async matchQueuedPlayers(now: Date): Promise<void> {
+  private async matchQueuedPlayers(now: Date, lock?: MatchmakingLockContext): Promise<void> {
     const requestsByPlayerId = await this.loadQueueRequests();
     const matchedPairs: Array<[MatchmakingRequest, MatchmakingRequest]> = [];
 
-    while (requestsByPlayerId.size >= 2) {
+    while (!lock?.isLockLost() && requestsByPlayerId.size >= 2) {
       const queue = Array.from(requestsByPlayerId.values());
       const selection = selectBestMatchPair(queue, now);
       if (!selection) {
@@ -614,7 +621,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       matchedPairs.push([left, right]);
     }
 
-    if (matchedPairs.length === 0) {
+    if (matchedPairs.length === 0 || lock?.isLockLost()) {
       return;
     }
 
@@ -663,7 +670,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     }
   }
 
-  private async withLock<T>(action: () => Promise<T>): Promise<T> {
+  private async withLock<T>(action: (lock: MatchmakingLockContext) => Promise<T>): Promise<T> {
     const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     const timeoutAt = Date.now() + this.lockTimeoutMs;
 
@@ -680,25 +687,43 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       await delay(this.lockRetryDelayMs);
     }
 
+    let lockLost = false;
+    let consecutiveRenewFailures = 0;
     const renewInterval = setInterval(() => {
+      if (lockLost) {
+        return;
+      }
       void this.renewLock(token).catch((error: unknown) => {
         recordMatchmakingLockRenewFailure();
+        consecutiveRenewFailures += 1;
         console.warn("[matchmaking] Redis lock renewal failed", {
           error: error instanceof Error ? error.message : String(error)
         });
+        if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
+          lockLost = true;
+          recordMatchmakingLockLost();
+          clearInterval(renewInterval);
+        }
       });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {
-      return await action();
+      const result = await action({ isLockLost: () => lockLost });
+      if (lockLost) {
+        throw new Error("Matchmaking lock lost mid-action; results discarded");
+      }
+      return result;
     } finally {
       clearInterval(renewInterval);
-      await this.releaseLock(token);
+      const released = await this.releaseLock(token);
+      if (!released) {
+        recordMatchmakingLockReleaseStale();
+      }
     }
   }
 
   private async renewLock(token: string): Promise<void> {
-    await this.redis.eval(
+    const renewed = await this.redis.eval(
       [
         "if redis.call('get', KEYS[1]) == ARGV[1] then",
         "  return redis.call('pexpire', KEYS[1], ARGV[2])",
@@ -710,10 +735,13 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       token,
       String(this.lockTimeoutMs)
     );
+    if (Number(renewed) !== 1) {
+      throw new Error("Redis matchmaking lock renewal lost ownership");
+    }
   }
 
-  private async releaseLock(token: string): Promise<void> {
-    await this.redis.eval(
+  private async releaseLock(token: string): Promise<boolean> {
+    const released = await this.redis.eval(
       [
         "if redis.call('get', KEYS[1]) == ARGV[1] then",
         "  return redis.call('del', KEYS[1])",
@@ -724,6 +752,7 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       this.lockKey,
       token
     );
+    return Number(released) === 1;
   }
 }
 

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -693,18 +693,22 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
       if (lockLost) {
         return;
       }
-      void this.renewLock(token).catch((error: unknown) => {
-        recordMatchmakingLockRenewFailure();
-        consecutiveRenewFailures += 1;
-        console.warn("[matchmaking] Redis lock renewal failed", {
-          error: error instanceof Error ? error.message : String(error)
+      void this.renewLock(token)
+        .then(() => {
+          consecutiveRenewFailures = 0;
+        })
+        .catch((error: unknown) => {
+          recordMatchmakingLockRenewFailure();
+          consecutiveRenewFailures += 1;
+          console.warn("[matchmaking] Redis lock renewal failed", {
+            error: error instanceof Error ? error.message : String(error)
+          });
+          if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
+            lockLost = true;
+            recordMatchmakingLockLost();
+            clearInterval(renewInterval);
+          }
         });
-        if (consecutiveRenewFailures >= MATCHMAKING_LOCK_RENEW_FAILURE_TOLERANCE) {
-          lockLost = true;
-          recordMatchmakingLockLost();
-          clearInterval(renewInterval);
-        }
-      });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {

--- a/apps/server/src/domain/social/matchmaking.ts
+++ b/apps/server/src/domain/social/matchmaking.ts
@@ -5,7 +5,11 @@ import { createMatchmakingHeroSnapshot, estimateMatchmakingWaitSeconds, type Mat
 import { resolveMapVariantIdForRoom } from "@veil/shared/world";
 import { validateAuthSessionFromRequest } from "@server/domain/account/auth";
 import { sendMobilePushNotification } from "@server/adapters/mobile-push";
-import { recordMatchmakingRateLimited, setMatchmakingQueueDepth } from "@server/domain/ops/observability";
+import {
+  recordMatchmakingLockRenewFailure,
+  recordMatchmakingRateLimited,
+  setMatchmakingQueueDepth
+} from "@server/domain/ops/observability";
 import type { RoomSnapshotStore } from "@server/persistence";
 import {
   consumeRedisBackedOrLocalRateLimit,
@@ -677,7 +681,12 @@ export class RedisMatchmakingService implements MatchmakingServiceController {
     }
 
     const renewInterval = setInterval(() => {
-      void this.renewLock(token);
+      void this.renewLock(token).catch((error: unknown) => {
+        recordMatchmakingLockRenewFailure();
+        console.warn("[matchmaking] Redis lock renewal failed", {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
     }, Math.max(100, Math.floor(this.lockTimeoutMs / 2)));
 
     try {

--- a/apps/server/src/transport/colyseus-room/VeilColyseusRoom.ts
+++ b/apps/server/src/transport/colyseus-room/VeilColyseusRoom.ts
@@ -240,7 +240,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       }
     });
     this.clock.setInterval(() => {
-      void this.tickMinorPlaytime();
+      void this.tickMinorPlaytime().catch((error) => {
+        this.reportMinorPlaytimeFailure(error);
+      });
     }, MINOR_PROTECTION_TICK_MS);
 
     this.onMessage("connect", async (client, message: Extract<ClientMessage, { type: "connect" }>) => {
@@ -1789,20 +1791,24 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         })
       );
     } catch (error) {
-      reportBackgroundTaskFailure({
-        taskType: "minor_playtime",
-        errorCode: "minor_playtime_tick_failed",
-        message: "Background minor-playtime tick failed.",
-        logMessage: "[VeilRoom] Failed to update minor playtime",
-        error,
-        roomId: this.metadata.logicalRoomId,
-        roomDay: this.worldRoom.getInternalState().meta.day,
-        detail: formatBackgroundTaskDetail("minor_playtime", error, {
-          connectedPlayers: playerIds.length,
-          playerIds: playerIds.join(",") || null
-        })
-      });
+      this.reportMinorPlaytimeFailure(error, playerIds);
     }
+  }
+
+  private reportMinorPlaytimeFailure(error: unknown, playerIds: string[] = []): void {
+    reportBackgroundTaskFailure({
+      taskType: "minor_playtime",
+      errorCode: "minor_playtime_tick_failed",
+      message: "Background minor-playtime tick failed.",
+      logMessage: "[VeilRoom] Failed to update minor playtime",
+      error,
+      roomId: this.metadata.logicalRoomId,
+      roomDay: this.worldRoom.getInternalState().meta.day,
+      detail: formatBackgroundTaskDetail("minor_playtime", error, {
+        connectedPlayers: playerIds.length,
+        playerIds: playerIds.join(",") || null
+      })
+    });
   }
 
   private async persistRoomState(): Promise<void> {

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -13,6 +13,7 @@ import {
   requeueAccountTokenDeliveryDeadLetter,
   resetAccountTokenDeliveryState
 } from "@server/adapters/account-token-delivery";
+import type { AccountTokenDeliveryQueuePersistence } from "@server/adapters/account-token-delivery";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 import type { RedisClientLike } from "@server/infra/redis";
 
@@ -545,6 +546,53 @@ test("redis token delivery persistence avoids full-list LREM scans on persistenc
     [],
     "token delivery persistence must not issue LREM count=0 full-list scans"
   );
+});
+
+test("queued token delivery pump lock failures are caught and counted", async (t) => {
+  resetRuntimeObservability();
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  const dueEntry = createQueuedDeliveryEntry("password-recovery:pump-ranger", Date.now() - 60_000);
+  let acquireCalls = 0;
+  const persistence: AccountTokenDeliveryQueuePersistence = {
+    async loadQueuedDeliveries() {
+      return [dueEntry];
+    },
+    async loadDeadLetterDeliveries() {
+      return [];
+    },
+    async loadDeadLetterDelivery() {
+      return null;
+    },
+    async saveQueuedDelivery() {},
+    async deleteQueuedDelivery() {},
+    async saveDeadLetterDelivery() {
+      return [];
+    },
+    async deleteDeadLetterDelivery() {},
+    async acquireProcessingLock() {
+      acquireCalls += 1;
+      throw new Error("lock unavailable");
+    }
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+  t.after(async () => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    resetRuntimeObservability();
+    resetAccountTokenDeliveryState();
+    await configureAccountTokenDeliveryQueuePersistence(null);
+  });
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  resetAccountTokenDeliveryState();
+  assert.ok(acquireCalls >= 1);
+  assert.deepEqual(unhandledRejections, []);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_queue_pump_failures_total 1$/m);
 });
 
 test("redis token delivery persistence caps dead-letter retention", async () => {

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -10,6 +10,7 @@ import {
   listAccountTokenDeliveryDeadLetters,
   readAccountRegistrationDeliveryMode,
   readPasswordRecoveryDeliveryMode,
+  requeueAccountTokenDeliveryDeadLetter,
   resetAccountTokenDeliveryState
 } from "@server/adapters/account-token-delivery";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
@@ -598,7 +599,7 @@ test("startup hydration trims preexisting dead-letter overflow and records drops
 
   await configureAccountTokenDeliveryQueuePersistence(persistence);
 
-  assert.deepEqual(listAccountTokenDeliveryDeadLetters().map((entry) => entry.key), [
+  assert.deepEqual((await listAccountTokenDeliveryDeadLetters()).map((entry) => entry.key), [
     "password-recovery:newest",
     "password-recovery:middle"
   ]);
@@ -613,6 +614,44 @@ test("startup hydration trims preexisting dead-letter overflow and records drops
   assert.match(metrics, /^veil_auth_token_delivery_dead_letter_capacity_used_ratio 1$/m);
 
   resetRuntimeObservability();
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
+test("admin dead-letter list and requeue read Redis persistence instead of local process cache", async () => {
+  const namespace = `account-token-delivery:admin-cross-pod:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const queuedHashKey = `${namespace}:queued`;
+  const queuedListKey = `${namespace}:queued-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 10
+  });
+  const entry = createQueuedDeliveryEntry("password-recovery:remote-pod", 1_800_000_180_000);
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+  await redis.hset(deadLetterHashKey, entry.key, JSON.stringify(entry));
+  await redis.rpush(deadLetterListKey, entry.key);
+
+  const deadLetters = await listAccountTokenDeliveryDeadLetters();
+  assert.deepEqual(deadLetters.map((snapshot) => snapshot.key), [entry.key]);
+
+  resetAccountTokenDeliveryState();
+  const requeued = await requeueAccountTokenDeliveryDeadLetter(entry.key);
+
+  assert.equal(requeued?.key, entry.key);
+  assert.equal(await redis.hget(deadLetterHashKey, entry.key), null);
+  const persistedQueued = JSON.parse((await redis.hget(queuedHashKey, entry.key)) ?? "{}") as {
+    key?: string;
+    attemptCount?: number;
+  };
+  assert.equal(persistedQueued.key, entry.key);
+  assert.equal(persistedQueued.attemptCount, 0);
+  assert.deepEqual(await redis.lrange(deadLetterListKey, 0, -1), []);
+  assert.deepEqual(await redis.lrange(queuedListKey, 0, -1), [entry.key]);
+
   resetAccountTokenDeliveryState();
   await configureAccountTokenDeliveryQueuePersistence(null);
 });
@@ -659,7 +698,7 @@ test("dead-letter cap evicts in-memory entries and records drops", async (t) => 
     );
   }
 
-  const deadLetterKeys = listAccountTokenDeliveryDeadLetters().map((entry) => entry.key);
+  const deadLetterKeys = (await listAccountTokenDeliveryDeadLetters()).map((entry) => entry.key);
   assert.equal(deadLetterKeys.includes("password-recovery:oldest"), false);
   assert.deepEqual(new Set(deadLetterKeys), new Set(["password-recovery:middle", "password-recovery:newest"]));
 

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -563,6 +563,60 @@ test("redis token delivery persistence caps dead-letter retention", async () => 
   );
 });
 
+test("startup hydration trims preexisting dead-letter overflow and records drops", async () => {
+  resetRuntimeObservability();
+  const namespace = `account-token-delivery:hydrate-cap:${Date.now()}`;
+  const deadLetterHashKey = `${namespace}:dead-letter`;
+  const deadLetterListKey = `${namespace}:dead-letter-keys`;
+  const redis = new MemoryRedisClient();
+  const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {
+    namespace,
+    deadLetterMaxEntries: 2
+  });
+
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:oldest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:oldest", 1_800_000_000_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:middle",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:middle", 1_800_000_060_000))
+  );
+  await redis.hset(
+    deadLetterHashKey,
+    "password-recovery:newest",
+    JSON.stringify(createQueuedDeliveryEntry("password-recovery:newest", 1_800_000_120_000))
+  );
+  await redis.rpush(
+    deadLetterListKey,
+    "password-recovery:oldest",
+    "password-recovery:middle",
+    "password-recovery:newest"
+  );
+
+  await configureAccountTokenDeliveryQueuePersistence(persistence);
+
+  assert.deepEqual(listAccountTokenDeliveryDeadLetters().map((entry) => entry.key), [
+    "password-recovery:newest",
+    "password-recovery:middle"
+  ]);
+  assert.deepEqual(
+    (await persistence.loadDeadLetterDeliveries()).map((entry) => entry.key),
+    ["password-recovery:middle", "password-recovery:newest"]
+  );
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_count 2$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_drops_total 1$/m);
+  assert.match(metrics, /^veil_auth_token_delivery_dead_letter_capacity_used_ratio 1$/m);
+
+  resetRuntimeObservability();
+  resetAccountTokenDeliveryState();
+  await configureAccountTokenDeliveryQueuePersistence(null);
+});
+
 test("dead-letter cap evicts in-memory entries and records drops", async (t) => {
   resetRuntimeObservability();
   const redis = new MemoryRedisClient();

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -595,6 +595,20 @@ test("queued token delivery pump lock failures are caught and counted", async (t
   assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_queue_pump_failures_total 1$/m);
 });
 
+test("queued token delivery processing lock is renewed and stale releases are counted", async () => {
+  const source = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("../src/adapters/account-token-delivery.ts", import.meta.url), "utf8")
+  );
+
+  assert.match(source, /renewProcessingLock\?/);
+  assert.match(source, /recordAuthTokenDeliveryProcessingLockRenewFailure/);
+  assert.match(source, /recordAuthTokenDeliveryProcessingLockLost/);
+  assert.match(source, /recordAuthTokenDeliveryProcessingLockReleaseStale/);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_processing_lock_renew_failures_total 0$/m);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_processing_lock_lost_total 0$/m);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_auth_token_delivery_processing_lock_release_stale_total 0$/m);
+});
+
 test("redis token delivery persistence caps dead-letter retention", async () => {
   const redis = new MemoryRedisClient();
   const persistence = createRedisAccountTokenDeliveryQueuePersistence(redis, {

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -565,6 +565,48 @@ test("getAnalyticsPipelineSnapshot aggregates Redis-backed counters across simul
   );
 });
 
+test("analytics flush trigger failures are caught and counted", async (t) => {
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandledRejection);
+  configureAnalyticsRuntimeDependencies({
+    error: () => {
+      throw new Error("analytics alert failed");
+    }
+  });
+
+  t.after(() => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    resetAnalyticsRuntimeDependencies();
+  });
+
+  for (let index = 0; index < 20; index += 1) {
+    emitAnalyticsEvent(
+      "session_start",
+      {
+        playerId: `player-${index}`,
+        source: "server",
+        payload: {
+          roomId: "room-a",
+          authMode: "guest",
+          platform: "web"
+        }
+      },
+      {
+        ANALYTICS_ENDPOINT: "https://placeholder.example/events"
+      }
+    );
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const snapshot = await getAnalyticsPipelineSnapshot();
+  assert.deepEqual(unhandledRejections, []);
+  assert.equal(snapshot.delivery.flushFailuresTotal, 1);
+  assert.match(snapshot.delivery.lastErrorMessage ?? "", /analytics alert failed/);
+});
+
 test("getAnalyticsPipelineSnapshot warns when http sink is requested without an endpoint", async () => {
   const snapshot = await getAnalyticsPipelineSnapshot({
     ANALYTICS_SINK: "http"

--- a/apps/server/test/colyseus-background-task-observability.test.ts
+++ b/apps/server/test/colyseus-background-task-observability.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
@@ -24,6 +25,16 @@ interface FakeClient extends Client {
 }
 
 class InstrumentedRoomSnapshotStore extends MemoryRoomSnapshotStore {}
+
+test("minor playtime interval catches fire-and-forget failures", async () => {
+  const source = await readFile(new URL("../src/transport/colyseus-room/VeilColyseusRoom.ts", import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /void this\.tickMinorPlaytime\(\)\.catch\(/,
+    "minor playtime interval must attach a catch handler to the fire-and-forget task"
+  );
+});
 
 async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
   await matchMaker.setup(

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -1147,6 +1147,7 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     createAccountTokenDeliveryQueuePersistence: () => ({
       loadQueuedDeliveries: async () => [],
       loadDeadLetterDeliveries: async () => [],
+      loadDeadLetterDelivery: async () => null,
       saveQueuedDelivery: async () => undefined,
       deleteQueuedDelivery: async () => undefined,
       saveDeadLetterDelivery: async () => [],

--- a/apps/server/test/event-admin-routes.test.ts
+++ b/apps/server/test/event-admin-routes.test.ts
@@ -3,6 +3,7 @@ import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { registerEventRoutes, resetSeasonalEventRuntimeState } from "@server/domain/battle/event-engine";
 import { issueGuestAuthSession } from "@server/domain/account/auth";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 
 type RouteHandler = (request: any, response: ServerResponse) => void | Promise<void>;
 
@@ -26,10 +27,18 @@ function createFakeEventClusterRedisClient() {
 function createFakeSeasonalEventOpsAuditRedisClient() {
   const lists = new Map<string, string[]>();
   const expireSecondsByKey = new Map<string, number>();
+  const failureMode = {
+    lpush: false,
+    lrange: false
+  };
 
   return {
     expireSecondsByKey,
+    failureMode,
     async lpush(key: string, ...values: string[]): Promise<number> {
+      if (failureMode.lpush) {
+        throw new Error("audit write unavailable");
+      }
       const list = lists.get(key) ?? [];
       list.unshift(...values);
       lists.set(key, list);
@@ -41,12 +50,19 @@ function createFakeSeasonalEventOpsAuditRedisClient() {
       return "OK";
     },
     async lrange(key: string, start: number, stop: number): Promise<string[]> {
+      if (failureMode.lrange) {
+        throw new Error("audit read unavailable");
+      }
       const list = lists.get(key) ?? [];
       return list.slice(start, stop + 1);
     },
     async expire(key: string, seconds: number): Promise<number> {
       expireSecondsByKey.set(key, seconds);
       return lists.has(key) ? 1 : 0;
+    },
+    async del(key: string): Promise<number> {
+      const existed = lists.delete(key);
+      return existed ? 1 : 0;
     }
   };
 }
@@ -484,6 +500,100 @@ test("PATCH /api/admin/seasonal-events/:id publishes audit rows across route ins
   assert.equal(listPayload.audit[0]?.eventId, "defend-the-bridge");
   assert.equal(listPayload.audit[0]?.occurredAt, "2026-04-04T12:00:00.000Z");
   assert.equal(redis.expireSecondsByKey.size, 1);
+});
+
+test("PATCH /api/admin/seasonal-events/:id surfaces degraded audit persistence", async (t) => {
+  resetRuntimeObservability();
+  t.after(() => {
+    resetSeasonalEventRuntimeState();
+    resetRuntimeObservability();
+  });
+  const token = withAdminToken(t);
+  const redis = createFakeSeasonalEventOpsAuditRedisClient();
+  redis.failureMode.lpush = true;
+  const { patches } = registerRoutes(createStore(), "2026-04-04T12:00:00.000Z", {
+    seasonalEventOpsAuditRedisClient: redis as never
+  } as unknown as Parameters<typeof registerEventRoutes>[2]);
+  const patchHandler = patches.get("/api/admin/seasonal-events/:id");
+  assert.ok(patchHandler);
+
+  const response = createResponse();
+  await patchHandler(
+    createRequest({
+      method: "PATCH",
+      headers: {
+        "x-veil-admin-token": token
+      },
+      params: {
+        id: "defend-the-bridge"
+      },
+      body: JSON.stringify({
+        isActive: false
+      })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.audit.action, "patched");
+  assert.equal(payload.auditDegraded, true);
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_seasonal_event_ops_audit_persist_failures_total 1$/m);
+  assert.match(metrics, /^veil_seasonal_event_ops_audit_local_fallback_writes_total 1$/m);
+});
+
+test("GET /api/admin/seasonal-events surfaces degraded audit reads", async (t) => {
+  resetRuntimeObservability();
+  t.after(() => {
+    resetSeasonalEventRuntimeState();
+    resetRuntimeObservability();
+  });
+  const token = withAdminToken(t);
+  const redis = createFakeSeasonalEventOpsAuditRedisClient();
+  const options = {
+    seasonalEventOpsAuditRedisClient: redis as never
+  } as unknown as Parameters<typeof registerEventRoutes>[2];
+  const routes = registerRoutes(createStore(), "2026-04-04T12:00:00.000Z", options);
+  const patchHandler = routes.patches.get("/api/admin/seasonal-events/:id");
+  const listHandler = routes.gets.get("/api/admin/seasonal-events");
+  assert.ok(patchHandler);
+  assert.ok(listHandler);
+
+  await patchHandler(
+    createRequest({
+      method: "PATCH",
+      headers: {
+        "x-veil-admin-token": token
+      },
+      params: {
+        id: "defend-the-bridge"
+      },
+      body: JSON.stringify({
+        isActive: false
+      })
+    }),
+    createResponse()
+  );
+
+  redis.failureMode.lrange = true;
+  const response = createResponse();
+  await listHandler(
+    createRequest({
+      headers: {
+        "x-veil-admin-token": token
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body);
+  assert.equal(payload.audit[0]?.action, "patched");
+  assert.equal(payload.auditDegraded, true);
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_seasonal_event_ops_audit_persist_success_total 1$/m);
+  assert.match(metrics, /^veil_seasonal_event_ops_audit_read_failures_total 1$/m);
 });
 
 test("POST /api/admin/seasonal-events/:id/end force-ends an active event and distributes mailbox rewards", async (t) => {

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -479,6 +479,48 @@ test("redis matchmaking lock renewal failures are caught and counted", async (t)
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });
 
+test("redis matchmaking lock renewal failure streak resets after successful renewals", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:renew-recovery",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 250
+  });
+  const originalEval = redis.eval.bind(redis);
+  const originalWarn = console.warn;
+  let renewAttempts = 0;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      renewAttempts += 1;
+      if (renewAttempts === 1 || renewAttempts === 3) {
+        await originalEval(...(args as [string, number, ...string[]]));
+        throw new Error("transient renew failed");
+      }
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  console.warn = () => undefined;
+
+  t.after(async () => {
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 430));
+  });
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.equal(renewAttempts >= 3, true);
+  assert.match(metrics, /^veil_matchmaking_lock_renew_failures_total 2$/m);
+  assert.match(metrics, /^veil_matchmaking_lock_lost_total 0$/m);
+});
+
 test("redis matchmaking stops before writing matches after repeated lock renewal failures", async (t) => {
   resetRuntimeObservability();
   const redis = new Redis();

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -437,6 +437,47 @@ test("redis matchmaking drains matched pairs with bounded Redis write round trip
   assert.match(resultGamma.roomId ?? "", /-2$/);
 });
 
+test("redis matchmaking rejects fenced writes after lock ownership changes", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const keyPrefix = "test:matchmaking:fenced-prewrite";
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix,
+    lockRetryDelayMs: 1
+  });
+  const queueKey = `${keyPrefix}:queue`;
+  const requestKey = `${keyPrefix}:requests`;
+  const resultKey = `${keyPrefix}:results`;
+  const lockKey = `${keyPrefix}:lock`;
+  const requests = [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:00.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:01.000Z")
+  ];
+
+  t.after(async () => {
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  for (const [index, request] of requests.entries()) {
+    await redis.zadd(queueKey, index, request.playerId);
+    await redis.hset(requestKey, request.playerId, JSON.stringify(request));
+  }
+  await redis.set(lockKey, "other-owner");
+
+  await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+    service,
+    new Date("2026-03-28T08:05:00.000Z"),
+    { isLockLost: () => false, token: "expected-owner" }
+  );
+
+  assert.deepEqual(await redis.zrange(queueKey, 0, -1), ["player-alpha", "player-beta"]);
+  assert.equal(await redis.hget(resultKey, "player-alpha"), null);
+  assert.equal(await redis.hget(resultKey, "player-beta"), null);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_fenced_write_rejected_total 1$/m);
+});
+
 test("redis matchmaking lock renewal failures are caught and counted", async (t) => {
   resetRuntimeObservability();
   const redis = new Redis();

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -571,3 +571,52 @@ test("redis matchmaking stops before writing matches after repeated lock renewal
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 2$/m);
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_lost_total 1$/m);
 });
+
+test("redis matchmaking fenced batch writes reject stale lock ownership", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const keyPrefix = "test:matchmaking:fenced-write";
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix,
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 250
+  });
+  const originalEval = redis.eval.bind(redis);
+  const lockKey = `${keyPrefix}:lock`;
+  const requestKey = `${keyPrefix}:requests`;
+  const queueKey = `${keyPrefix}:queue`;
+  const resultKey = `${keyPrefix}:results`;
+  const originalWarn = console.warn;
+
+  t.after(async () => {
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  console.warn = () => undefined;
+  await redis.hset(requestKey, "player-alpha", JSON.stringify(createQueueRequest("player-alpha", "2026-03-29T00:00:00.000Z")));
+  await redis.hset(requestKey, "player-beta", JSON.stringify(createQueueRequest("player-beta", "2026-03-29T00:00:01.000Z")));
+  await redis.zadd(queueKey, 1, "player-alpha", 2, "player-beta");
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("hset") && script.includes("zrem")) {
+      await redis.set(lockKey, "other-token");
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+
+  await Reflect.get(service as Record<string, unknown>, "withLock").call(service, async (lock: unknown) => {
+    await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+      service,
+      new Date("2026-03-29T00:00:00.000Z"),
+      lock
+    );
+  });
+
+  assert.equal(await redis.hget(resultKey, "player-alpha"), null);
+  assert.deepEqual(await redis.zrange(queueKey, 0, -1), ["player-alpha", "player-beta"]);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_fenced_write_rejected_total 1$/m);
+});

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import Redis from "ioredis-mock";
 import { createDefaultHeroLoadout, createDefaultHeroProgression, type HeroState } from "@veil/shared/models";
 import { createMatchmakingHeroSnapshot, type MatchmakingRequest } from "@veil/shared/social";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "@server/domain/ops/observability";
 import { MatchmakingService, RedisMatchmakingService } from "@server/domain/social/matchmaking";
 
 test("redis matchmaking queue lifecycle does not remove players with full list scans", async () => {
@@ -434,4 +435,46 @@ test("redis matchmaking drains matched pairs with bounded Redis write round trip
   const resultGamma = JSON.parse((await redis.hget(resultKey, "player-gamma")) ?? "{}") as { roomId?: string };
   assert.match(resultAlpha.roomId ?? "", /-1$/);
   assert.match(resultGamma.roomId ?? "", /-2$/);
+});
+
+test("redis matchmaking lock renewal failures are caught and counted", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:renew-failure",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 200
+  });
+  const originalEval = redis.eval.bind(redis);
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  const originalWarn = console.warn;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      throw new Error("renew failed");
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  console.warn = () => undefined;
+  process.on("unhandledRejection", onUnhandledRejection);
+
+  t.after(async () => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+    await new Promise((resolve) => setTimeout(resolve, 160));
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(unhandledRejections, []);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -357,3 +357,81 @@ test("redis matchmaking batches queue request reads while draining multiple pair
   assert.equal(hmgetCalls.length, 1);
   assert.equal(hgetCalls.length, 0);
 });
+
+test("redis matchmaking drains matched pairs with bounded Redis write round trips", async (t) => {
+  const redis = new Redis();
+  const keyPrefix = "test:matchmaking:batch-write";
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix,
+    lockRetryDelayMs: 1
+  });
+  const queueKey = `${keyPrefix}:queue`;
+  const requestKey = `${keyPrefix}:requests`;
+  const resultKey = `${keyPrefix}:results`;
+  const evalCalls: unknown[][] = [];
+  const zremCalls: unknown[][] = [];
+  const hdelCalls: unknown[][] = [];
+  const hsetCalls: unknown[][] = [];
+  const incrCalls: unknown[][] = [];
+  const originalEval = redis.eval.bind(redis);
+  const originalZrem = redis.zrem.bind(redis);
+  const originalHdel = redis.hdel.bind(redis);
+  const originalHset = redis.hset.bind(redis);
+  const originalIncr = redis.incr.bind(redis);
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    evalCalls.push(args);
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  (redis as unknown as { zrem: (...args: unknown[]) => Promise<number> }).zrem = async (...args) => {
+    zremCalls.push(args);
+    return originalZrem(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hdel: (...args: unknown[]) => Promise<number> }).hdel = async (...args) => {
+    hdelCalls.push(args);
+    return originalHdel(...(args as [string, ...string[]]));
+  };
+  (redis as unknown as { hset: (...args: unknown[]) => Promise<number> }).hset = async (...args) => {
+    hsetCalls.push(args);
+    return originalHset(...(args as [string, string, string]));
+  };
+  (redis as unknown as { incr: (...args: unknown[]) => Promise<number> }).incr = async (...args) => {
+    incrCalls.push(args);
+    return originalIncr(...(args as [string]));
+  };
+
+  t.after(async () => {
+    await service.close();
+  });
+
+  const requests = [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:00.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:01.000Z"),
+    createQueueRequest("player-gamma", "2026-03-28T08:00:02.000Z"),
+    createQueueRequest("player-delta", "2026-03-28T08:00:03.000Z")
+  ];
+
+  for (const [index, request] of requests.entries()) {
+    await redis.zadd(queueKey, index, request.playerId);
+    await redis.hset(requestKey, request.playerId, JSON.stringify(request));
+  }
+  hsetCalls.length = 0;
+
+  await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+    service,
+    new Date("2026-03-28T08:05:00.000Z")
+  );
+
+  assert.equal(await redis.zcard(queueKey), 0);
+  assert.equal(zremCalls.length, 0);
+  assert.equal(hdelCalls.length, 0);
+  assert.equal(hsetCalls.length, 0);
+  assert.equal(incrCalls.length, 0);
+  assert.equal(evalCalls.length, 2);
+
+  const resultAlpha = JSON.parse((await redis.hget(resultKey, "player-alpha")) ?? "{}") as { roomId?: string };
+  const resultGamma = JSON.parse((await redis.hget(resultKey, "player-gamma")) ?? "{}") as { roomId?: string };
+  assert.match(resultAlpha.roomId ?? "", /-1$/);
+  assert.match(resultGamma.roomId ?? "", /-2$/);
+});

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -478,3 +478,54 @@ test("redis matchmaking lock renewal failures are caught and counted", async (t)
   assert.deepEqual(unhandledRejections, []);
   assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 1$/m);
 });
+
+test("redis matchmaking stops before writing matches after repeated lock renewal failures", async (t) => {
+  resetRuntimeObservability();
+  const redis = new Redis();
+  const service = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:lock-lost",
+    lockRetryDelayMs: 1,
+    lockTimeoutMs: 250
+  });
+  const originalEval = redis.eval.bind(redis);
+  let zremCalls = 0;
+  const originalZrem = redis.zrem.bind(redis);
+  const originalWarn = console.warn;
+
+  (redis as unknown as { eval: (...args: unknown[]) => Promise<unknown> }).eval = async (...args) => {
+    const [script] = args;
+    if (typeof script === "string" && script.includes("pexpire")) {
+      throw new Error("renew failed");
+    }
+    return originalEval(...(args as [string, number, ...string[]]));
+  };
+  (redis as unknown as { zrem: (...args: unknown[]) => Promise<unknown> }).zrem = async (...args) => {
+    zremCalls += 1;
+    return originalZrem(...(args as [string, ...string[]]));
+  };
+  console.warn = () => undefined;
+
+  t.after(async () => {
+    console.warn = originalWarn;
+    resetRuntimeObservability();
+    await service.close();
+  });
+
+  await assert.rejects(
+    () =>
+      Reflect.get(service as Record<string, unknown>, "withLock").call(service, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 270));
+        await Reflect.get(service as Record<string, unknown>, "matchQueuedPlayers").call(
+          service,
+          new Date("2026-03-29T00:00:00.000Z")
+        );
+      }),
+    /Matchmaking lock lost/
+  );
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(zremCalls, 0);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_renew_failures_total 2$/m);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_matchmaking_lock_lost_total 1$/m);
+});


### PR DESCRIPTION
## Summary
- Escape query-derived `roomId` and `playerId` in the H5 session metadata renderer
- Add a focused regression test for hostile query values

## Verification
- `node --import tsx --test apps/client/test/main-session-meta.test.ts`
- `npm run typecheck -- client`
- `git diff --check`

Fixes #1771.