### PR TITLE
Fix token delivery lock renew persistence capture

### DIFF
--- a/apps/server/src/adapters/account-token-delivery.ts
+++ b/apps/server/src/adapters/account-token-delivery.ts
@@ -1178,12 +1178,13 @@ async function processQueuedDelivery(entry: QueuedDeliveryEntry): Promise<void> 
 }
 
 async function withQueueProcessingLock(action: (lock: QueueProcessingLockContext) => Promise<void>): Promise<void> {
-  if (!queuePersistence?.acquireProcessingLock) {
+  const persistence = queuePersistence;
+  if (!persistence?.acquireProcessingLock) {
     await action({ isLockLost: () => false });
     return;
   }
 
-  const lockAcquired = await queuePersistence.acquireProcessingLock(QUEUE_PROCESSING_LOCK_TTL_MS);
+  const lockAcquired = await persistence.acquireProcessingLock(QUEUE_PROCESSING_LOCK_TTL_MS);
   if (!lockAcquired) {
     scheduleQueuePump();
     return;
@@ -1192,13 +1193,13 @@ async function withQueueProcessingLock(action: (lock: QueueProcessingLockContext
   let lockLost = false;
   let consecutiveRenewFailures = 0;
   const renewInterval =
-    queuePersistence.renewProcessingLock &&
+    persistence.renewProcessingLock &&
     setInterval(() => {
       if (lockLost) {
         return;
       }
-      void queuePersistence
-        ?.renewProcessingLock?.(QUEUE_PROCESSING_LOCK_TTL_MS)
+      void persistence
+        .renewProcessingLock?.(QUEUE_PROCESSING_LOCK_TTL_MS)
         .then(() => {
           consecutiveRenewFailures = 0;
         })
@@ -1227,7 +1228,7 @@ async function withQueueProcessingLock(action: (lock: QueueProcessingLockContext
     if (renewInterval) {
       clearInterval(renewInterval);
     }
-    const released = await queuePersistence.releaseProcessingLock?.();
+    const released = await persistence.releaseProcessingLock?.();
     if (released === false) {
       recordAuthTokenDeliveryProcessingLockReleaseStale();
     }

--- a/apps/server/test/account-token-delivery.test.ts
+++ b/apps/server/test/account-token-delivery.test.ts
@@ -601,6 +601,9 @@ test("queued token delivery processing lock is renewed and stale releases are co
   );
 
   assert.match(source, /renewProcessingLock\?/);
+  assert.match(source, /const persistence = queuePersistence;/);
+  assert.doesNotMatch(source, /queuePersistence\s*\?\s*\.\s*renewProcessingLock/);
+  assert.doesNotMatch(source, /queuePersistence\s*\.\s*releaseProcessingLock/);
   assert.match(source, /recordAuthTokenDeliveryProcessingLockRenewFailure/);
   assert.match(source, /recordAuthTokenDeliveryProcessingLockLost/);
   assert.match(source, /recordAuthTokenDeliveryProcessingLockReleaseStale/);


### PR DESCRIPTION
Fixes #1773.

Changes:
- Capture account-token queue persistence once for lock acquire/renew/release.
- Extend the lock-renew regression to reject renew/release reads through the mutable global.

Verification:
- RED: `node --import tsx --test --test-name-pattern "processing lock is renewed" apps/server/test/account-token-delivery.test.ts` failed after temporarily restoring the old global reads.
- GREEN: `node --import tsx --test --test-name-pattern "processing lock is renewed" apps/server/test/account-token-delivery.test.ts`
- `npm run typecheck -- server`
- `git diff --check`